### PR TITLE
[APIPUB-33] .NET 8 upgrade 

### DIFF
--- a/.github/workflows/after-pullrequest.yml
+++ b/.github/workflows/after-pullrequest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload Test Results
-        uses: dorny/test-reporter@0d00bb14cb0cc2c9b8985df6e81dd333188224e1 # v1.5.0
+        uses: dorny/test-reporter@eaa763f6ffc21c7a37837f56cd5f9737f27fc6c8 # v1.8.0
         with:
           artifact: csharp-tests
           name: C# Unit Test Results

--- a/.github/workflows/after-pullrequest.yml
+++ b/.github/workflows/after-pullrequest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload Test Results
-        uses: dorny/test-reporter@eaa763f6ffc21c7a37837f56cd5f9737f27fc6c8  # v1.8.0
+        uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226   # v1.6.0
         with:
           artifact: csharp-tests
           name: C# Unit Test Results

--- a/.github/workflows/after-pullrequest.yml
+++ b/.github/workflows/after-pullrequest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload Test Results
-        uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226   # v1.6.0
+        uses: dorny/test-reporter@0d00bb14cb0cc2c9b8985df6e81dd333188224e1 # v1.5.0
         with:
           artifact: csharp-tests
           name: C# Unit Test Results

--- a/.github/workflows/after-pullrequest.yml
+++ b/.github/workflows/after-pullrequest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload Test Results
-        uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6.0
+        uses: dorny/test-reporter@eaa763f6ffc21c7a37837f56cd5f9737f27fc6c8  # v1.8.0
         with:
           artifact: csharp-tests
           name: C# Unit Test Results

--- a/.github/workflows/on-merge-or-tag.yml
+++ b/.github/workflows/on-merge-or-tag.yml
@@ -26,7 +26,7 @@ jobs:
         shell: pwsh
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
         with:
           # MinVer needs to have more than just the current commit, so tell
           # GitHub to get many more. Setting to 0 forces retrieval of _all_

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Publish .NET Assemblies
         run: |

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload Packages as Artifacts
         if: success()
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8  # v4.3.0
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: "${{ env.PACKAGE_NAME }}-NuGet"
           path: ./*.nupkg

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -28,7 +28,7 @@ jobs:
       api-pub-version: ${{ steps.versions.outputs.api-pub }}
 
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
         with:
           fetch-depth: 0
 
@@ -62,7 +62,7 @@ jobs:
               -Version $appVersion
 
       - name: Setup Nuget.exe
-        uses: nuget/setup-nuget@fd9fffd6ca4541cf4152a9565835ca1a88a6eb37 #v1.1.1
+        uses: nuget/setup-nuget@a21f25cd3998bf370fde17e3f1b4c12c175172f9  #v2.0.0
 
       - name: Create NuGet Packages
         if: success()
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload Packages as Artifacts
         if: success()
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8  # v4.3.0
         with:
           name: "${{ env.PACKAGE_NAME }}-NuGet"
           path: ./*.nupkg
@@ -100,10 +100,10 @@ jobs:
     outputs:
       sbom-hash-code: ${{ steps.sbom-hash-code.outputs.sbom-hash-code }}
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Get Artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 #v4.1.1
         with:
           name: ${{ env.PACKAGE_NAME }}-NuGet
 
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload SBOM
         if: success()
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: ${{ env.PACKAGE_NAME }}-SBOM
           path: ./manifest
@@ -160,7 +160,7 @@ jobs:
       contents: write
     steps:
       - name: Download the SBOM
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@7f4fdb871876c23e455853d694197440c5a91506 #v1.5.0
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@07e64b653f10a80b6510f4568f685f8b7b9ea830  # v1.9.0
         with:
           name: "${{ env.PACKAGE_NAME }}-SBOM"
           path: ${{ env.MANIFEST_FILE }}
@@ -216,10 +216,10 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
 
       - name: Get Artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 #v4.1.1
         with:
           name: ${{ env.PACKAGE_NAME }}-NuGet
 

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Build
         run: ./build.ps1 -Command Build -Configuration Debug

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -44,7 +44,7 @@ jobs:
         run: ./build.ps1 -Command UnitTest -Configuration Debug
 
       - name: Upload Results as Workflow Artifact
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: csharp-tests
           path: "**/*.trx"

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -29,7 +29,7 @@ jobs:
         shell: pwsh
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup .NET
         uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
@@ -44,17 +44,17 @@ jobs:
         run: ./build.ps1 -Command UnitTest -Configuration Debug
 
       - name: Upload Results as Workflow Artifact
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: csharp-tests
           path: "**/*.trx"
           retention-days: 5
 
       - name: Dependency Review ("Dependabot on PR")
-        uses: actions/dependency-review-action@c090f4e553673e6e505ea70d6a95362ee12adb94 # v3.0.3
+        uses: actions/dependency-review-action@4901385134134e04cec5fbe5ddfe3b2c5bd5d976 # v4.0.0
       - name: Initialize CodeQL
         if: success()
-        uses: github/codeql-action/init@896079047b4bb059ba6f150a5d87d47dde99e6e5 # codeql-bundle-20221211
+        uses: github/codeql-action/init@cf7e9f23492505046de9a37830c3711dd0f25bb3 # codeql-bundle-v2.16.2
         with:
           languages: csharp
 
@@ -63,4 +63,4 @@ jobs:
 
       - name: Perform CodeQL Analysis
         if: success()
-        uses: github/codeql-action/analyze@896079047b4bb059ba6f150a5d87d47dde99e6e5 # codeql-bundle-20221211
+        uses: github/codeql-action/analyze@cf7e9f23492505046de9a37830c3711dd0f25bb3 # codeql-bundle-v2.16.2

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Delete other pre-releases and their tags
         shell: pwsh
@@ -52,4 +52,4 @@ jobs:
             $page += 1
           } While ($release_list.count -gt 0)
 
- # Manually doing promote pacakges to release on azure artifacts
+ # Manually doing promote packages to release on azure artifacts

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For Ed-Fi ODS / API 5.1 through 5.3 only: create and assign a claim set for the 
 
 ### Use the API Publisher
 
-The API Publisher has three options to use the product.  The API Publisher requires [.NET Core 3.1](https://dotnet.microsoft.com/en-us/download/dotnet/3.1) to run:
+The API Publisher has three options to use the product.  The API Publisher requires [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) to run:
 
 #### Option 1 - From binaries
 
@@ -49,7 +49,7 @@ If you would like to build the API Publisher from source, build the solution by 
 
 `dotnet build`
 
-The API Publisher executable (`EdFiApiPublisher.exe`) will be located in the _.\EdFi.Tools.ApiPublisher.Cli\bin\Debug\netcoreapp3.1_ subfolder.
+The API Publisher executable (`EdFiApiPublisher.exe`) will be located in the _.\EdFi.Tools.ApiPublisher.Cli\bin\Debug\net8.0_ subfolder.
 
 ### Publish Data to Local Sandbox
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Tag aspnet:6.0-alpine
-FROM mcr.microsoft.com/dotnet/aspnet@sha256:201cedd60cb295b2ebea7184561a45c5c0ee337e37300ea0f25cff5a2c762538
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:789045ecae51d62d07877994d567eff4442b7bbd4121867898ee7bf00b7241ea
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV VERSION="1.0.0"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Tag aspnet:8.0-alpine
-FROM mcr.microsoft.com/dotnet/aspnet@sha256:789045ecae51d62d07877994d567eff4442b7bbd4121867898ee7bf00b7241ea
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:95f27052830db1c7a00e55f098ebda507204757907919f506a468387f7d856a4
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV VERSION="1.0.0"
@@ -21,7 +21,7 @@ COPY ./Docker/plainTextNamedConnections.template.json /app/plainTextNamedConnect
 
 COPY ./Docker/run.sh /app/run.sh
 
-RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 postgresql13-client=~13 icu=~72 curl=~8 && \
+RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 postgresql13-client=~13 icu=~74 curl=~8 && \
     wget -O /app/ApiPublisher.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.ApiPublisher/versions/${VERSION}/content && \
     unzip /app/ApiPublisher.zip 'EdFi.ApiPublisher/**' -d /app/ && \
     mv /app/EdFi.ApiPublisher/* /app/ && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-# Tag aspnet:6.0-alpine
+# Tag aspnet:8.0-alpine
 FROM mcr.microsoft.com/dotnet/aspnet@sha256:789045ecae51d62d07877994d567eff4442b7bbd4121867898ee7bf00b7241ea
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 

--- a/src/EdFi.Tools.ApiPublisher.Cli/EdFi.Tools.ApiPublisher.Cli.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Cli/EdFi.Tools.ApiPublisher.Cli.csproj
@@ -8,9 +8,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.304.6" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.302.12" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.AwsCloudWatch" Version="4.0.171" />
+    <PackageReference Include="Serilog.Sinks.AwsCloudWatch" Version="4.0.182" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />

--- a/src/EdFi.Tools.ApiPublisher.Cli/EdFi.Tools.ApiPublisher.Cli.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Cli/EdFi.Tools.ApiPublisher.Cli.csproj
@@ -1,57 +1,52 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <AssemblyName>EdFiApiPublisher</AssemblyName>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
-        <NoWarn>NU5100, NU5124</NoWarn>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.2" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-      <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
-      <PackageReference Include="Serilog.Sinks.AwsCloudWatch" Version="4.0.171" />
-      <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-      <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <None Update="apiPublisherSettings.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-      <None Update="logging.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-      <None Update="plainTextNamedConnections.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="appSettings.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-      <None Update="appSettings.Development.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-      <None Update="configurationStoreSettings.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.ConfigurationStore.Aws\EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj" />
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext\EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext.csproj" />
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql\EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql.csproj" />
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer\EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer.csproj" />
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Sqlite\EdFi.Tools.ApiPublisher.Connections.Sqlite.csproj" />
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>EdFiApiPublisher</AssemblyName>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+    <NoWarn>NU5100, NU5124</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.AwsCloudWatch" Version="4.0.171" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="apiPublisherSettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="logging.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="plainTextNamedConnections.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appSettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="appSettings.Development.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="configurationStoreSettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.ConfigurationStore.Aws\EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj" />
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext\EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext.csproj" />
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql\EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql.csproj" />
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer\EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer.csproj" />
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Sqlite\EdFi.Tools.ApiPublisher.Connections.Sqlite.csproj" />
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/EdFi.Tools.ApiPublisher.Cli/EdFi.Tools.ApiPublisher.Cli.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Cli/EdFi.Tools.ApiPublisher.Cli.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.AwsCloudWatch" Version="4.0.171" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj
@@ -4,7 +4,7 @@
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.1" />
+    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="6.0.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.300" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.302.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj
@@ -4,9 +4,9 @@
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.3.11" />
+    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.1" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.300" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.302.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj
@@ -1,20 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
-      <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
-      <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.3.11" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.3.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext/EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext/EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql.csproj
@@ -4,7 +4,7 @@
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="5.0.5" />
+    <PackageReference Include="Npgsql" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
   </ItemGroup>

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql.csproj
@@ -1,19 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Npgsql" Version="5.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer/EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer/EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer.csproj
@@ -1,18 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.3" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />
-      <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.3.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />
+    <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/EdFi.Tools.ApiPublisher.Connections.Api.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/EdFi.Tools.ApiPublisher.Connections.Api.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
+    <PackageReference Include="Autofac" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/EdFi.Tools.ApiPublisher.Connections.Sqlite/EdFi.Tools.ApiPublisher.Connections.Sqlite.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Sqlite/EdFi.Tools.ApiPublisher.Connections.Sqlite.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.5.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.0" />
+    <PackageReference Include="Autofac" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.2" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/EdFi.Tools.ApiPublisher.Core/EdFi.Tools.ApiPublisher.Core.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Core/EdFi.Tools.ApiPublisher.Core.csproj
@@ -1,26 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="Autofac" Version="6.5.0" />
-      <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
-      <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.2" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="Polly" Version="7.2.2" />
-      <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-      <PackageReference Include="Serilog" Version="2.12.0" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-      <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="8.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.1" />
+    <PackageReference Include="Polly" Version="7.2.2" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/EdFi.Tools.ApiPublisher.Core/EdFi.Tools.ApiPublisher.Core.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Core/EdFi.Tools.ApiPublisher.Core.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Autofac" Version="8.0.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.1" />
-    <PackageReference Include="Polly" Version="7.2.2" />
+    <PackageReference Include="Polly" Version="8.3.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />

--- a/src/EdFi.Tools.ApiPublisher.Core/EdFi.Tools.ApiPublisher.Core.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Core/EdFi.Tools.ApiPublisher.Core.csproj
@@ -6,11 +6,11 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="8.0.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.1" />
+    <PackageReference Include="Jering.Javascript.NodeJS" Version="7.0.0" />
     <PackageReference Include="Polly" Version="8.3.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />

--- a/src/EdFi.Tools.ApiPublisher.Core/NodeJs/NullNodeJsService.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/NodeJs/NullNodeJsService.cs
@@ -138,4 +138,9 @@ public class NullNodeJsService : INodeJSService
     {
         throw new NotImplementedException();
     }
+
+    ValueTask INodeJSService.MoveToNewProcessAsync()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/EdFi.Tools.ApiPublisher.Tests/EdFi.Tools.ApiPublisher.Tests.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Tests/EdFi.Tools.ApiPublisher.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />

--- a/src/EdFi.Tools.ApiPublisher.Tests/EdFi.Tools.ApiPublisher.Tests.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Tests/EdFi.Tools.ApiPublisher.Tests.csproj
@@ -1,29 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="33.1.1" />
-    <PackageReference Include="FakeItEasy" Version="7.2.0" />
-    <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Bogus" Version="35.4.0" />
+    <PackageReference Include="FakeItEasy" Version="8.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="8.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.2" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Resources\Dependencies-GraphML-v5.2.xml" />
   </ItemGroup>
-
 </Project>

--- a/src/EdFi.Tools.ApiPublisher.Tests/EdFi.Tools.ApiPublisher.Tests.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Tests/EdFi.Tools.ApiPublisher.Tests.csproj
@@ -7,10 +7,10 @@
     <PackageReference Include="Bogus" Version="35.4.0" />
     <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.1" />
+    <PackageReference Include="Jering.Javascript.NodeJS" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />

--- a/src/EdFi.Tools.ApiPublisher.Tests/Processing/RemediationIntegrationTests.cs
+++ b/src/EdFi.Tools.ApiPublisher.Tests/Processing/RemediationIntegrationTests.cs
@@ -875,6 +875,11 @@ public class RemediationIntegrationTests
             throw new NotImplementedException();
         }
 
+        ValueTask INodeJSService.MoveToNewProcessAsync()
+        {
+            throw new NotImplementedException();
+        }
+
         #endregion
     }
 }

--- a/src/EdFi.Tools.ApiPublisher.sln
+++ b/src/EdFi.Tools.ApiPublisher.sln
@@ -1,22 +1,22 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Tools.ApiPublisher.Cli", "EdFi.Tools.ApiPublisher.Cli\EdFi.Tools.ApiPublisher.Cli.csproj", "{3B38EB1C-5E15-4DFA-8E08-73F000BA3DC9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Tools.ApiPublisher.Cli", "EdFi.Tools.ApiPublisher.Cli\EdFi.Tools.ApiPublisher.Cli.csproj", "{3B38EB1C-5E15-4DFA-8E08-73F000BA3DC9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Tools.ApiPublisher.Core", "EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj", "{482A7531-642C-460C-B682-EB1CE4F01F54}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Tools.ApiPublisher.Core", "EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj", "{482A7531-642C-460C-B682-EB1CE4F01F54}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Tools.ApiPublisher.ConfigurationStore.Aws", "EdFi.Tools.ApiPublisher.ConfigurationStore.Aws\EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj", "{609536D2-C903-45CC-BAF2-63039791593C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Tools.ApiPublisher.ConfigurationStore.Aws", "EdFi.Tools.ApiPublisher.ConfigurationStore.Aws\EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj", "{609536D2-C903-45CC-BAF2-63039791593C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer", "EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer\EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer.csproj", "{08CA1DB7-B451-4E83-91B6-2E22B4BE7B31}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer", "EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer\EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer.csproj", "{08CA1DB7-B451-4E83-91B6-2E22B4BE7B31}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql", "EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql\EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql.csproj", "{E0F3EDB1-3FB2-45B7-BDD5-D7DBDF0E4645}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql", "EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql\EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql.csproj", "{E0F3EDB1-3FB2-45B7-BDD5-D7DBDF0E4645}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Tools.ApiPublisher.Tests", "EdFi.Tools.ApiPublisher.Tests\EdFi.Tools.ApiPublisher.Tests.csproj", "{F4335A14-FF6A-484A-B7CB-7F759C1E4CB3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Tools.ApiPublisher.Tests", "EdFi.Tools.ApiPublisher.Tests\EdFi.Tools.ApiPublisher.Tests.csproj", "{F4335A14-FF6A-484A-B7CB-7F759C1E4CB3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Tools.ApiPublisher.Connections.Sqlite", "EdFi.Tools.ApiPublisher.Connections.Sqlite\EdFi.Tools.ApiPublisher.Connections.Sqlite.csproj", "{D33B235E-09E5-45E8-AAFE-DB3AFAFFF080}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Tools.ApiPublisher.Connections.Sqlite", "EdFi.Tools.ApiPublisher.Connections.Sqlite\EdFi.Tools.ApiPublisher.Connections.Sqlite.csproj", "{D33B235E-09E5-45E8-AAFE-DB3AFAFFF080}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Tools.ApiPublisher.Connections.Api", "EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj", "{CCCE6AC0-9F8C-423D-88C6-8B63C0A56299}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Tools.ApiPublisher.Connections.Api", "EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj", "{CCCE6AC0-9F8C-423D-88C6-8B63C0A56299}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext", "EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext\EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext.csproj", "{624C34FE-DA4D-41F0-B791-738D91422ACB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext", "EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext\EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext.csproj", "{624C34FE-DA4D-41F0-B791-738D91422ACB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/dev.Dockerfile
+++ b/src/dev.Dockerfile
@@ -5,7 +5,7 @@
 
 
 # tag sdk:8.0 alpine
-FROM mcr.microsoft.com/dotnet/sdk@sha256:4b684e6c74ab8dff26ac54c79d8242b1dd05aba06c367de2b583bad79fd6399b AS build
+FROM mcr.microsoft.com/dotnet/sdk@sha256:e646d8a0fa589bcd970e0ebde394780398e8ae08fffeb36781753c51fc9e87b0 AS build
 WORKDIR /source
 
 COPY ./EdFi.Tools.ApiPublisher.Cli/ EdFi.Tools.ApiPublisher.Cli/
@@ -36,7 +36,7 @@ RUN dotnet publish -c Release -o /app/EdFi.Tools.ApiPiblisher.Cli --no-build --n
 
 
 # Tag aspnet:8.0 alpine
-FROM mcr.microsoft.com/dotnet/aspnet@sha256:789045ecae51d62d07877994d567eff4442b7bbd4121867898ee7bf00b7241ea
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:95f27052830db1c7a00e55f098ebda507204757907919f506a468387f7d856a4
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 # Alpine image does not contain Globalization Cultures library so we need to install ICU library to get fopr LINQ expression to work
@@ -52,7 +52,7 @@ COPY ./Docker/logging.template.json /app/logging.template.json
 COPY ./Docker/plainTextNamedConnections.template.json /app/plainTextNamedConnections.template.json
 COPY ./Docker/run.sh /app/run.sh
 
-RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~72 curl=~8 && \
+RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~74 curl=~8 && \
     dos2unix /app/*.json && \
     dos2unix /app/*.sh && \
     chmod 700 /app/*.sh -- ** && \

--- a/src/dev.Dockerfile
+++ b/src/dev.Dockerfile
@@ -3,6 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
+
 # tag sdk:8.0 alpine
 FROM mcr.microsoft.com/dotnet/sdk@sha256:4b684e6c74ab8dff26ac54c79d8242b1dd05aba06c367de2b583bad79fd6399b AS build
 WORKDIR /source
@@ -34,7 +35,7 @@ FROM build AS publish
 RUN dotnet publish -c Release -o /app/EdFi.Tools.ApiPiblisher.Cli --no-build --nologo
 
 
-# Tag aspnet:8.0-alpine
+# Tag aspnet:8.0 alpine
 FROM mcr.microsoft.com/dotnet/aspnet@sha256:789045ecae51d62d07877994d567eff4442b7bbd4121867898ee7bf00b7241ea
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 

--- a/src/dev.Dockerfile
+++ b/src/dev.Dockerfile
@@ -3,8 +3,8 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-# tag sdk:7.0 alpine
-FROM mcr.microsoft.com/dotnet/sdk@sha256:5117ed094f21df9d4244b618de3bed2e16f24c504056b03d7569b83dc4900a65 AS build
+# tag sdk:8.0 alpine
+FROM mcr.microsoft.com/dotnet/sdk@sha256:4b684e6c74ab8dff26ac54c79d8242b1dd05aba06c367de2b583bad79fd6399b AS build
 WORKDIR /source
 
 COPY ./EdFi.Tools.ApiPublisher.Cli/ EdFi.Tools.ApiPublisher.Cli/
@@ -34,8 +34,8 @@ FROM build AS publish
 RUN dotnet publish -c Release -o /app/EdFi.Tools.ApiPiblisher.Cli --no-build --nologo
 
 
-# Tag aspnet:6.0-alpine
-FROM mcr.microsoft.com/dotnet/aspnet@sha256:201cedd60cb295b2ebea7184561a45c5c0ee337e37300ea0f25cff5a2c762538
+# Tag aspnet:8.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:789045ecae51d62d07877994d567eff4442b7bbd4121867898ee7bf00b7241ea
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 # Alpine image does not contain Globalization Cultures library so we need to install ICU library to get fopr LINQ expression to work


### PR DESCRIPTION
- Upgrade projects to use .NET 8.
- Upgrade nugets to the latest version.
- Update github actions to use the new NET version.
- Update docker files to reference .NET 8.
- Update documentation.
- Upgrade actions to replace deprecated versions.

PS. [To run this solution you will need Visual Studio 17.8 (Visual Studio 2022)](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/version-requirements) 