### PR TITLE
[APIPUB-65] SPIKE: Determine rate limiting approach

### DIFF
--- a/src/EdFi.Tools.ApiPublisher.Cli/apiPublisherSettings.json
+++ b/src/EdFi.Tools.ApiPublisher.Cli/apiPublisherSettings.json
@@ -1,18 +1,21 @@
 {
-  "options": {
-    "bearerTokenRefreshMinutes": 28,
-    "retryStartingDelayMilliseconds": 100,
-    "maxRetryAttempts": 5,
-    "maxDegreeOfParallelismForResourceProcessing": 7,
-    "maxDegreeOfParallelismForPostResourceItem": 15,
-    "maxDegreeOfParallelismForStreamResourcePages": 5,
-    "streamingPagesWaitDurationSeconds": 10,
-    "streamingPageSize": 500,
-    "includeDescriptors": false,
-    "errorPublishingBatchSize": 25,
-    "useChangeVersionPaging": false,
-    "changeVersionPagingWindowSize": 25000
-  },
+    "options": {
+        "bearerTokenRefreshMinutes": 28,
+        "retryStartingDelayMilliseconds": 100,
+        "maxRetryAttempts": 5,
+        "maxDegreeOfParallelismForResourceProcessing": 7,
+        "maxDegreeOfParallelismForPostResourceItem": 15,
+        "maxDegreeOfParallelismForStreamResourcePages": 5,
+        "streamingPagesWaitDurationSeconds": 10,
+        "streamingPageSize": 500,
+        "includeDescriptors": false,
+        "errorPublishingBatchSize": 25,
+        "useChangeVersionPaging": false,
+        "changeVersionPagingWindowSize": 25000,
+        "enableRateLimit": false,
+        "rateLimitNumberExecutions": 100,
+        "rateLimitTimeLimitMinutes": 1
+    },
     "authorizationFailureHandling": [
         {
             "path": "/ed-fi/students",

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/EdFi.Tools.ApiPublisher.Connections.Api.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/EdFi.Tools.ApiPublisher.Connections.Api.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Polly.RateLimiting" Version="8.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/Counting/EdFiApiSourceTotalCountProvider.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/Counting/EdFiApiSourceTotalCountProvider.cs
@@ -47,12 +47,12 @@ public class EdFiApiSourceTotalCountProvider : ISourceTotalCountProvider
         int attempt = 0;
 		// Rate Limit
 		bool isRateLimitingEnabled = options.EnableRateLimit;
-		var retryPolicy = Policy.RateLimitAsync<HttpResponseMessage>(
+		var rateLimiterPolicy = Policy.RateLimitAsync<HttpResponseMessage>(
 			options.RateLimitNumberExecutions,
 			TimeSpan.FromMinutes(options.RateLimitTimeLimitMinutes)
 		);
 
-        var rateLimiterPolicy = Policy
+        var retryPolicy = Policy
             .HandleResult<HttpResponseMessage>(r => r.StatusCode.IsPotentiallyTransientFailure())
             .WaitAndRetryAsync(delay, (result, ts, retryAttempt, ctx) =>
             {

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageHandlers/EdFiApiStreamResourcePageMessageHandler.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageHandlers/EdFiApiStreamResourcePageMessageHandler.cs
@@ -70,10 +70,10 @@ public class EdFiApiStreamResourcePageMessageHandler : IStreamResourcePageMessag
                     options.MaxRetryAttempts);
 
                 int attempts = 0;
-				// Rate Limit
-                bool isRateLimitingEnabled = options.EnableRateLimit; 
-				var rateLimiterPolicy = Policy.RateLimitAsync<HttpResponseMessage>(
-                    options.RateLimitNumberExecutions, 
+                // Rate Limit
+                bool isRateLimitingEnabled = options.EnableRateLimit;
+                var rateLimiterPolicy = Policy.RateLimitAsync<HttpResponseMessage>(
+                    options.RateLimitNumberExecutions,
                     TimeSpan.FromMinutes(options.RateLimitTimeLimitMinutes)
                 );
 
@@ -86,9 +86,10 @@ public class EdFiApiStreamResourcePageMessageHandler : IStreamResourcePageMessag
                             _logger.Warning(
                                 $"{message.ResourceUrl}: Retrying GET page items {offset} to {offset + limit - 1} from source failed with status '{result.Result.StatusCode}'. Retrying... (retry #{retryAttempt} of {options.MaxRetryAttempts} with {ts.TotalSeconds:N1}s delay)");
                         });
-				IAsyncPolicy<HttpResponseMessage> policy = isRateLimitingEnabled ? Policy.WrapAsync(rateLimiterPolicy, retryPolicy) : retryPolicy;
-                try { 
-				    var apiResponse = await policy.ExecuteAsync(
+                IAsyncPolicy<HttpResponseMessage> policy = isRateLimitingEnabled ? Policy.WrapAsync(rateLimiterPolicy, retryPolicy) : retryPolicy;
+                try
+                {
+                    var apiResponse = await policy.ExecuteAsync(
                             (ctx, ct) =>
                             {
                                 attempts++;
@@ -151,7 +152,7 @@ public class EdFiApiStreamResourcePageMessageHandler : IStreamResourcePageMessag
                     // Transform the page content to item actions
                     try
                     {
-                        transformedMessages.AddRange( message.CreateProcessDataMessages(message, responseContent));
+                        transformedMessages.AddRange(message.CreateProcessDataMessages(message, responseContent));
                     }
                     catch (JsonReaderException ex)
                     {
@@ -190,21 +191,21 @@ public class EdFiApiStreamResourcePageMessageHandler : IStreamResourcePageMessag
                         continue;
                     }
 
-				}
-				catch (RateLimiterRejectedException ex)
-				{
-					// Handle RateLimiterRejectedException,
-					// that can optionally contain information about when to retry.
-					if (ex.RetryAfter.HasValue)
-					{
-						_logger.Warning($"{message.ResourceUrl}: Rate limit exceeded. Please retry after: {ex.RetryAfter.Value.TotalSeconds} seconds.");
-					}
-					else
-					{
-						_logger.Warning($"{message.ResourceUrl}: Rate limit exceeded. Please try again later.");
-					}
-				}
-				break;
+                }
+                catch (RateLimiterRejectedException ex)
+                {
+                    // Handle RateLimiterRejectedException,
+                    // that can optionally contain information about when to retry.
+                    if (ex.RetryAfter.HasValue)
+                    {
+                        _logger.Warning($"{message.ResourceUrl}: Rate limit exceeded. Please retry after: {ex.RetryAfter.Value.TotalSeconds} seconds.");
+                    }
+                    else
+                    {
+                        _logger.Warning($"{message.ResourceUrl}: Rate limit exceeded. Please try again later.");
+                    }
+                }
+                break;
             }
             while (true);
 
@@ -224,7 +225,7 @@ public class EdFiApiStreamResourcePageMessageHandler : IStreamResourcePageMessag
 
             // Publish the failure
             errorHandlingBlock.Post(error);
-            
+
             return Array.Empty<TProcessDataMessage>();
         }
     }

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/ChangeResourceKeyProcessingBlocksFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/ChangeResourceKeyProcessingBlocksFactory.cs
@@ -24,12 +24,12 @@ using System.Threading.Tasks.Dataflow;
 
 namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
 {
-	/// <summary>
-	/// Builds a pipeline that processes key changes against a target Ed-Fi ODS API.
-	/// </summary>
-	/// <remarks>Receives a <see cref="GetItemForKeyChangeMessage" />, transforms to a <see cref="ChangeKeyMessage" /> before
-	/// producing <see cref="ErrorItemMessage" /> instances as output. </remarks>
-	public class ChangeResourceKeyProcessingBlocksFactory : IProcessingBlocksFactory<GetItemForKeyChangeMessage>
+    /// <summary>
+    /// Builds a pipeline that processes key changes against a target Ed-Fi ODS API.
+    /// </summary>
+    /// <remarks>Receives a <see cref="GetItemForKeyChangeMessage" />, transforms to a <see cref="ChangeKeyMessage" /> before
+    /// producing <see cref="ErrorItemMessage" /> instances as output. </remarks>
+    public class ChangeResourceKeyProcessingBlocksFactory : IProcessingBlocksFactory<GetItemForKeyChangeMessage>
     {
         private readonly ITargetEdFiApiClientProvider _targetEdFiApiClientProvider;
 
@@ -39,7 +39,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
         {
             _targetEdFiApiClientProvider = targetEdFiApiClientProvider;
         }
-        
+
         public (ITargetBlock<GetItemForKeyChangeMessage>, ISourceBlock<ErrorItemMessage>) CreateProcessingBlocks(
             CreateBlocksRequest createBlocksRequest)
         {
@@ -49,7 +49,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                     createBlocksRequest.Options,
                     createBlocksRequest.ErrorHandlingBlock);
 
-            TransformManyBlock<ChangeKeyMessage, ErrorItemMessage> changeKeyResourceBlock 
+            TransformManyBlock<ChangeKeyMessage, ErrorItemMessage> changeKeyResourceBlock
                 = CreateChangeKeyBlock(_targetEdFiApiClientProvider.GetApiClient(), createBlocksRequest.Options);
 
             getItemForKeyChangeBlock.LinkTo(changeKeyResourceBlock, new DataflowLinkOptions { PropagateCompletion = true });
@@ -58,8 +58,8 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
         }
 
         private TransformManyBlock<GetItemForKeyChangeMessage, ChangeKeyMessage> CreateGetItemForKeyChangeBlock(
-            EdFiApiClient targetApiClient, 
-            Options options, 
+            EdFiApiClient targetApiClient,
+            Options options,
             ITargetBlock<ErrorItemMessage> errorHandlingBlock)
         {
             var getItemForKeyChangeBlock = new TransformManyBlock<GetItemForKeyChangeMessage, ChangeKeyMessage>(
@@ -70,7 +70,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                     {
                         return Enumerable.Empty<ChangeKeyMessage>();
                     }
-                    
+
                     string sourceId = message.SourceId;
 
                     try
@@ -80,18 +80,18 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                             .Select(p => $"{p.Name}={WebUtility.UrlEncode(GetQueryStringValue(p))}");
 
                         string queryString = String.Join("&", keyValueParms);
-                    
+
                         var delay = Backoff.ExponentialBackoff(
                             TimeSpan.FromMilliseconds(options.RetryStartingDelayMilliseconds),
                             options.MaxRetryAttempts);
 
                         int attempts = 0;
-						// Rate Limit
-						bool isRateLimitingEnabled = options.EnableRateLimit;
-						var rateLimiterPolicy = Policy.RateLimitAsync<HttpResponseMessage>(
-							options.RateLimitNumberExecutions,
-							TimeSpan.FromMinutes(options.RateLimitTimeLimitMinutes)
-						);
+                        // Rate Limit
+                        bool isRateLimitingEnabled = options.EnableRateLimit;
+                        var rateLimiterPolicy = Policy.RateLimitAsync<HttpResponseMessage>(
+                            options.RateLimitNumberExecutions,
+                            TimeSpan.FromMinutes(options.RateLimitTimeLimitMinutes)
+                        );
 
                         var retryPolicy = Policy
                             .Handle<Exception>()
@@ -109,31 +109,31 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                                 }
                             });
 
-						IAsyncPolicy<HttpResponseMessage> policy = isRateLimitingEnabled ? Policy.WrapAsync(rateLimiterPolicy, retryPolicy) : retryPolicy;
-						
+                        IAsyncPolicy<HttpResponseMessage> policy = isRateLimitingEnabled ? Policy.WrapAsync(rateLimiterPolicy, retryPolicy) : retryPolicy;
+
                         var apiResponse = await policy.ExecuteAsync((ctx, ct) =>
-						{
-                                attempts++;
+                        {
+                            attempts++;
 
-                                if (attempts > 1)
+                            if (attempts > 1)
+                            {
+                                if (_logger.IsEnabled(LogEventLevel.Debug))
                                 {
-                                    if (_logger.IsEnabled(LogEventLevel.Debug))
-                                    {
-                                        _logger.Debug($"{message.ResourceUrl} (source id: {message.SourceId}): GET by key on target attempt #{attempts} ({queryString}).");
-                                    }
+                                    _logger.Debug($"{message.ResourceUrl} (source id: {message.SourceId}): GET by key on target attempt #{attempts} ({queryString}).");
                                 }
+                            }
 
-                                return targetApiClient.HttpClient.GetAsync($"{targetApiClient.DataManagementApiSegment}{message.ResourceUrl}?{queryString}", ct);
-                            }, new Context(), CancellationToken.None);
+                            return targetApiClient.HttpClient.GetAsync($"{targetApiClient.DataManagementApiSegment}{message.ResourceUrl}?{queryString}", ct);
+                        }, new Context(), CancellationToken.None);
 
                         // Detect null content and provide a better error message (which happens during unit testing if mocked requests aren't properly defined)
                         if (apiResponse.Content == null)
                         {
                             throw new NullReferenceException($"Content of response for '{targetApiClient.HttpClient.BaseAddress}{message.ResourceUrl}?{queryString}' was null.");
                         }
-                        
+
                         string responseContent = await apiResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        
+
                         // Failure
                         if (!apiResponse.IsSuccessStatusCode)
                         {
@@ -152,7 +152,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
 
                             // Publish the failure
                             errorHandlingBlock.Post(error);
-                        
+
                             // No key changes to process
                             return Enumerable.Empty<ChangeKeyMessage>();
                         }
@@ -168,7 +168,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                         {
                             _logger.Debug($"{message.ResourceUrl} (source id: {sourceId}): GET by key returned {apiResponse.StatusCode}");
                         }
-                        
+
                         var getByKeyResults = JArray.Parse(responseContent);
 
                         // If the item whose key is to be changed cannot be found...
@@ -178,16 +178,16 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                             {
                                 _logger.Warning($"{message.ResourceUrl} (source id: {sourceId}): GET by key for key change returned no results on target API ({queryString}).");
                             }
-                            
+
                             // No key changes to process
                             return Enumerable.Empty<ChangeKeyMessage>();
                         }
-                        
+
                         // Get the resource item
                         var existingResourceItem = getByKeyResults[0] as JObject;
 
                         // Remove the id and etag properties
-                        string targetId = existingResourceItem["id"].Value<string>(); 
+                        string targetId = existingResourceItem["id"].Value<string>();
                         existingResourceItem.Property("id")?.Remove();
                         existingResourceItem.Property("_etag")?.Remove();
 
@@ -196,11 +196,12 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                             .Concat(
                                 existingResourceItem.Properties()
                                     .Where(p => p.Value.Type == JTokenType.Object && p.Name.EndsWith("Reference"))
-                                    .SelectMany(reference => {
+                                    .SelectMany(reference =>
+                                    {
                                         // Remove the link from the reference while we're here
                                         var referenceAsJObject = reference.Value as JObject;
                                         referenceAsJObject.Property("link")?.Remove();
-            
+
                                         // Return the reference's properties as potential keyChange value updates
                                         return referenceAsJObject.Properties();
                                     })
@@ -212,13 +213,13 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                         {
                             var newValueProperty = newKeyValues.Property(candidateProperty.Name);
 
-                            if (newValueProperty != null) 
+                            if (newValueProperty != null)
                             {
                                 if (_logger.IsEnabled(LogEventLevel.Debug))
                                 {
                                     _logger.Debug($"{message.ResourceUrl} (source id: {message.SourceId}): Assigning new value for '{candidateProperty.Name}' as '{newValueProperty.Value}'...");
                                 }
-                                
+
                                 candidateProperty.Value = newValueProperty.Value;
                             }
                         }
@@ -234,21 +235,21 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                             }
                         };
                     }
-					catch (RateLimiterRejectedException ex)
-					{
-						// Handle RateLimiterRejectedException,
-						// that can optionally contain information about when to retry.
-						if (ex.RetryAfter.HasValue)
-						{
-							_logger.Warning($"{message.ResourceUrl}: Rate limit exceeded. Please retry after: {ex.RetryAfter.Value.TotalSeconds} seconds.");
-						}
-						else
-						{
-							_logger.Warning($"{message.ResourceUrl}: Rate limit exceeded. Please try again later.");
-						}
+                    catch (RateLimiterRejectedException ex)
+                    {
+                        // Handle RateLimiterRejectedException,
+                        // that can optionally contain information about when to retry.
+                        if (ex.RetryAfter.HasValue)
+                        {
+                            _logger.Warning($"{message.ResourceUrl}: Rate limit exceeded. Please retry after: {ex.RetryAfter.Value.TotalSeconds} seconds.");
+                        }
+                        else
+                        {
+                            _logger.Warning($"{message.ResourceUrl}: Rate limit exceeded. Please try again later.");
+                        }
                         throw;
-					}
-					catch (Exception ex)
+                    }
+                    catch (Exception ex)
                     {
                         _logger.Error($"{message.ResourceUrl} (source id: {sourceId}): An unhandled exception occurred in the block created by '{nameof(CreateGetItemForKeyChangeBlock)}': {ex}");
                         throw;
@@ -257,7 +258,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                 {
                     MaxDegreeOfParallelism = options.MaxDegreeOfParallelismForPostResourceItem
                 });
-            
+
             return getItemForKeyChangeBlock;
 
             string GetQueryStringValue(JProperty property)
@@ -273,7 +274,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                         {
                             return dateValue.ToString("yyyy-MM-dd");
                         }
-                        
+
                         return JsonConvert.SerializeObject(property.Value).Trim('"');
                     case JTokenType.TimeSpan:
                         return JsonConvert.SerializeObject(property.Value).Trim('"');
@@ -282,7 +283,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                 }
             }
         }
-        
+
         private TransformManyBlock<ChangeKeyMessage, ErrorItemMessage> CreateChangeKeyBlock(
             EdFiApiClient targetApiClient, Options options)
         {
@@ -299,12 +300,12 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                         options.MaxRetryAttempts);
 
                     int attempt = 0;
-					// Rate Limit
-					bool isRateLimitingEnabled = options.EnableRateLimit;
-					var rateLimiterPolicy = Policy.RateLimitAsync<HttpResponseMessage>(
-						options.RateLimitNumberExecutions,
-						TimeSpan.FromMinutes(options.RateLimitTimeLimitMinutes)
-					);
+                    // Rate Limit
+                    bool isRateLimitingEnabled = options.EnableRateLimit;
+                    var rateLimiterPolicy = Policy.RateLimitAsync<HttpResponseMessage>(
+                        options.RateLimitNumberExecutions,
+                        TimeSpan.FromMinutes(options.RateLimitTimeLimitMinutes)
+                    );
                     var retryPolicy = Policy
                         .Handle<Exception>()
                         .OrResult<HttpResponseMessage>(r =>
@@ -322,8 +323,8 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                             }
                         });
 
-					IAsyncPolicy<HttpResponseMessage> policy = isRateLimitingEnabled ? Policy.WrapAsync(rateLimiterPolicy, retryPolicy) : retryPolicy;
-					
+                    IAsyncPolicy<HttpResponseMessage> policy = isRateLimitingEnabled ? Policy.WrapAsync(rateLimiterPolicy, retryPolicy) : retryPolicy;
+
                     var apiResponse = await policy.ExecuteAsync((ctx, ct) =>
                         {
                             attempt++;
@@ -335,18 +336,18 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                                     _logger.Debug($"{msg.ResourceUrl} (source id: {sourceId}): PUT request to update key (attempt #{attempt}.");
                                 }
                             }
-                                
+
                             return targetApiClient.HttpClient.PutAsync(
                                 $"{targetApiClient.DataManagementApiSegment}{msg.ResourceUrl}/{id}",
-                                new StringContent(msg.Body, Encoding.UTF8, "application/json"), 
+                                new StringContent(msg.Body, Encoding.UTF8, "application/json"),
                                 ct);
                         }, new Context(), CancellationToken.None);
-                    
+
                     // Failure
                     if (!apiResponse.IsSuccessStatusCode)
                     {
                         string responseContent = await apiResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                                
+
                         _logger.Error(
                             $"{msg.ResourceUrl} (source id: {sourceId}): PUT returned {apiResponse.StatusCode}{Environment.NewLine}{responseContent}");
 
@@ -361,9 +362,9 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                             ResponseContent = responseContent
                         };
 
-                        return new[] {error};
+                        return new[] { error };
                     }
-                    
+
                     // Success
                     if (_logger.IsEnabled(LogEventLevel.Information) && attempt > 1)
                     {
@@ -375,25 +376,25 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                     {
                         _logger.Debug($"{msg.ResourceUrl} (source id: {sourceId}): PUT returned {apiResponse.StatusCode}");
                     }
-                    
+
                     // Success - no errors to publish
                     return Enumerable.Empty<ErrorItemMessage>();
                 }
-				catch (RateLimiterRejectedException ex)
-				{
-					// Handle RateLimiterRejectedException,
-					// that can optionally contain information about when to retry.
-					if (ex.RetryAfter.HasValue)
-					{
-						_logger.Warning($"{msg.ResourceUrl}: Rate limit exceeded. Please retry after: {ex.RetryAfter.Value.TotalSeconds} seconds.");
-					}
-					else
-					{
-						_logger.Warning($"{msg.ResourceUrl}: Rate limit exceeded. Please try again later.");
-					}
-					throw;
-				}
-				catch (Exception ex)
+                catch (RateLimiterRejectedException ex)
+                {
+                    // Handle RateLimiterRejectedException,
+                    // that can optionally contain information about when to retry.
+                    if (ex.RetryAfter.HasValue)
+                    {
+                        _logger.Warning($"{msg.ResourceUrl}: Rate limit exceeded. Please retry after: {ex.RetryAfter.Value.TotalSeconds} seconds.");
+                    }
+                    else
+                    {
+                        _logger.Warning($"{msg.ResourceUrl}: Rate limit exceeded. Please try again later.");
+                    }
+                    throw;
+                }
+                catch (Exception ex)
                 {
                     _logger.Error($"{msg.ResourceUrl} (source id: {sourceId}): An unhandled exception occurred in the ChangeResourceKey block: {ex}");
                     throw;
@@ -460,12 +461,12 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                     // TODO: GKM - Should we add a flag for specifying that publishing without proper key change support from source API is ok?
                     _logger.Warning($"Source API's '{EdFiApiConstants.KeyChangesPathSuffix}' response does not include the domain key values. Publishing of key changes to the target API cannot be performed.");
                     _logger.Debug("Attempting to gracefully cancel key change processing due to lack of support for key values from the source API.");
-                
+
                     message.CancellationSource.Cancel();
-                
+
                     return null;
                 }
-            
+
                 return new GetItemForKeyChangeMessage
                 {
                     ResourceUrl = message.ResourceUrl.TrimSuffix(EdFiApiConstants.KeyChangesPathSuffix),

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/PostResourceProcessingBlocksFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/PostResourceProcessingBlocksFactory.cs
@@ -31,7 +31,7 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
 {
-	public class PostResourceProcessingBlocksFactory : IProcessingBlocksFactory<PostItemMessage>
+    public class PostResourceProcessingBlocksFactory : IProcessingBlocksFactory<PostItemMessage>
     {
         private readonly ILogger _logger = Log.ForContext(typeof(PostResourceProcessingBlocksFactory));
         private readonly INodeJSService _nodeJsService;
@@ -76,7 +76,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
             var knownUnremediatedRequests = new HashSet<(string resourceUrl, HttpStatusCode statusCode)>();
 
             var options = createBlocksRequest.Options;
-            
+
             var targetEdFiApiClient = _targetEdFiApiClientProvider.GetApiClient();
 
             var javaScriptModuleFactory = createBlocksRequest.JavaScriptModuleFactory;
@@ -99,12 +99,12 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
             }
 
             var postResourceBlock = new TransformManyBlock<PostItemMessage, ErrorItemMessage>(
-                async msg => 
+                async msg =>
                     await HandlePostItemMessage(
-                        ignoredResourceByUrl, 
-                        msg, 
-                        options, 
-                        javaScriptModuleFactory, 
+                        ignoredResourceByUrl,
+                        msg,
+                        options,
+                        javaScriptModuleFactory,
                         targetEdFiApiClient,
                         knownUnremediatedRequests,
                         missingDependencyByResourcePath),
@@ -157,12 +157,12 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                     options.MaxRetryAttempts);
 
                 int attempts = 0;
-				// Rate Limit
-				bool isRateLimitingEnabled = options.EnableRateLimit;
-				var rateLimiterPolicy = Policy.RateLimitAsync<HttpResponseMessage>(
-					options.RateLimitNumberExecutions,
-					TimeSpan.FromMinutes(options.RateLimitTimeLimitMinutes)
-				);
+                // Rate Limit
+                bool isRateLimitingEnabled = options.EnableRateLimit;
+                var rateLimiterPolicy = Policy.RateLimitAsync<HttpResponseMessage>(
+                    options.RateLimitNumberExecutions,
+                    TimeSpan.FromMinutes(options.RateLimitTimeLimitMinutes)
+                );
                 var retryPolicy = Policy.Handle<Exception>()
                     .OrResult<HttpResponseMessage>(
                         r =>
@@ -228,88 +228,88 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                                 _logger.Warning(
                                     $"{postItemMessage.ResourceUrl} (source id: {id}): POST attempt #{attempts} failed with status '{result.Result.StatusCode}'. Retrying... (retry #{retryAttempt} of {options.MaxRetryAttempts} with {ts.TotalSeconds:N1}s delay):{Environment.NewLine}{responseContent}");
                             }
-						});
-				IAsyncPolicy<HttpResponseMessage> policy = isRateLimitingEnabled ? Policy.WrapAsync(rateLimiterPolicy, retryPolicy) : retryPolicy;
-				var apiResponse = await policy.ExecuteAsync(
-				async (ctx, ct) =>
-				{
-                            attempts++;
+                        });
+                IAsyncPolicy<HttpResponseMessage> policy = isRateLimitingEnabled ? Policy.WrapAsync(rateLimiterPolicy, retryPolicy) : retryPolicy;
+                var apiResponse = await policy.ExecuteAsync(
+                async (ctx, ct) =>
+                {
+                    attempts++;
 
-                            if (_logger.IsEnabled(LogEventLevel.Debug))
-                            {
-                                if (attempts > 1)
-                                {
-                                    _logger.Debug($"{postItemMessage.ResourceUrl} (source id: {id}): POST attempt #{attempts}.");
-                                }
-                                else
-                                {
-                                    _logger.Debug($"{postItemMessage.ResourceUrl} (source id: {id}): Sending POST request.");
-                                }
-                            }
+                    if (_logger.IsEnabled(LogEventLevel.Debug))
+                    {
+                        if (attempts > 1)
+                        {
+                            _logger.Debug($"{postItemMessage.ResourceUrl} (source id: {id}): POST attempt #{attempts}.");
+                        }
+                        else
+                        {
+                            _logger.Debug($"{postItemMessage.ResourceUrl} (source id: {id}): Sending POST request.");
+                        }
+                    }
 
-                            // Prepare request body
-                            string requestBodyJson;
+                    // Prepare request body
+                    string requestBodyJson;
 
-                            if (ctx.TryGetValue("ModifiedRequestBody", out dynamic modifiedRequestBody))
-                            {
-                                _logger.Information(
-                                    $"{postItemMessage.ResourceUrl} (source id: {id}): Applying modified request body from remediation plan...");
+                    if (ctx.TryGetValue("ModifiedRequestBody", out dynamic modifiedRequestBody))
+                    {
+                        _logger.Information(
+                            $"{postItemMessage.ResourceUrl} (source id: {id}): Applying modified request body from remediation plan...");
 
-                                requestBodyJson = JsonSerializer.Serialize(modifiedRequestBody);
-                            }
-                            else
-                            {
-                                requestBodyJson = postItemMessage.Item.ToString();
-                            }
+                        requestBodyJson = JsonSerializer.Serialize(modifiedRequestBody);
+                    }
+                    else
+                    {
+                        requestBodyJson = postItemMessage.Item.ToString();
+                    }
 
-                            var response = await RequestHelpers.SendPostRequestAsync(
-                                targetEdFiApiClient,
-                                postItemMessage.ResourceUrl,
-                                $"{targetEdFiApiClient.DataManagementApiSegment}{postItemMessage.ResourceUrl}",
-                                requestBodyJson,
-                                ct);
+                    var response = await RequestHelpers.SendPostRequestAsync(
+                        targetEdFiApiClient,
+                        postItemMessage.ResourceUrl,
+                        $"{targetEdFiApiClient.DataManagementApiSegment}{postItemMessage.ResourceUrl}",
+                        requestBodyJson,
+                        ct);
 
-                            var (hasMissingDependency, missingDependencyDetails) = await TryGetMissingDependencyDetailsAsync(response, postItemMessage);
-                            
-                            if (hasMissingDependency)
-                            {
-                                if (!_sourceCapabilities.SupportsGetItemById)
-                                {
-                                    _logger.Warning(
-                                        $"{postItemMessage.ResourceUrl}: Reference '{missingDependencyDetails!.ReferenceName}' to resource '{missingDependencyDetails.ReferencedResourceName}' could not be automatically resolved because the source connection does not support retrieving items by id.");
+                    var (hasMissingDependency, missingDependencyDetails) = await TryGetMissingDependencyDetailsAsync(response, postItemMessage);
 
-                                    return response;
-                                }
+                    if (hasMissingDependency)
+                    {
+                        if (!_sourceCapabilities.SupportsGetItemById)
+                        {
+                            _logger.Warning(
+                                $"{postItemMessage.ResourceUrl}: Reference '{missingDependencyDetails!.ReferenceName}' to resource '{missingDependencyDetails.ReferencedResourceName}' could not be automatically resolved because the source connection does not support retrieving items by id.");
 
-                                _logger.Information(
-                                    $"{postItemMessage.ResourceUrl}: Attempting to retrieve missing '{missingDependencyDetails.ReferencedResourceName}' reference based on 'authorizationFailureHandling' metadata in apiPublisherSettings.json.");
-
-                                var (missingDependencyItemRetrieved, missingItemJson) = await _sourceResourceItemProvider.TryGetResourceItemAsync(missingDependencyDetails.SourceDependencyItemUrl);
-                                    
-                                if (missingDependencyItemRetrieved)
-                                {
-                                    var missingItem = JObject.Parse(missingItemJson!);
-
-                                    var postDependencyItemMessage = new PostItemMessage
-                                    {
-                                        ResourceUrl = missingDependencyDetails.DependencyResourceUrl,
-                                        Item = missingItem,
-                                        PostAuthorizationFailureRetry = postItemMessage.PostAuthorizationFailureRetry, // TODO: Is this appropriate to copy?
-                                    };
-                                    
-                                    await HandlePostItemMessage(
-                                        ignoredResourceByUrl,
-                                        postDependencyItemMessage!,
-                                        options,
-                                        javaScriptModuleFactory,
-                                        targetEdFiApiClient,
-                                        knownUnremediatedRequests,
-                                        missingDependencyByResourcePath);
-                                }
-                            }
-                            
                             return response;
-                        },
+                        }
+
+                        _logger.Information(
+                            $"{postItemMessage.ResourceUrl}: Attempting to retrieve missing '{missingDependencyDetails.ReferencedResourceName}' reference based on 'authorizationFailureHandling' metadata in apiPublisherSettings.json.");
+
+                        var (missingDependencyItemRetrieved, missingItemJson) = await _sourceResourceItemProvider.TryGetResourceItemAsync(missingDependencyDetails.SourceDependencyItemUrl);
+
+                        if (missingDependencyItemRetrieved)
+                        {
+                            var missingItem = JObject.Parse(missingItemJson!);
+
+                            var postDependencyItemMessage = new PostItemMessage
+                            {
+                                ResourceUrl = missingDependencyDetails.DependencyResourceUrl,
+                                Item = missingItem,
+                                PostAuthorizationFailureRetry = postItemMessage.PostAuthorizationFailureRetry, // TODO: Is this appropriate to copy?
+                            };
+
+                            await HandlePostItemMessage(
+                                ignoredResourceByUrl,
+                                postDependencyItemMessage!,
+                                options,
+                                javaScriptModuleFactory,
+                                targetEdFiApiClient,
+                                knownUnremediatedRequests,
+                                missingDependencyByResourcePath);
+                        }
+                    }
+
+                    return response;
+                },
                         new Context(),
                         CancellationToken.None);
 
@@ -410,21 +410,21 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                 // Success - no errors to publish
                 return Enumerable.Empty<ErrorItemMessage>();
             }
-			catch (RateLimiterRejectedException ex)
-			{
-				// Handle RateLimiterRejectedException,
-				// that can optionally contain information about when to retry.
-				if (ex.RetryAfter.HasValue)
-				{
-					_logger.Warning($"{postItemMessage.ResourceUrl}: Rate limit exceeded. Please retry after: {ex.RetryAfter.Value.TotalSeconds} seconds.");
-				}
-				else
-				{
-					_logger.Warning($"{postItemMessage.ResourceUrl}: Rate limit exceeded. Please try again later.");
-				}
-				throw;
-			}
-			catch (Exception ex)
+            catch (RateLimiterRejectedException ex)
+            {
+                // Handle RateLimiterRejectedException,
+                // that can optionally contain information about when to retry.
+                if (ex.RetryAfter.HasValue)
+                {
+                    _logger.Warning($"{postItemMessage.ResourceUrl}: Rate limit exceeded. Please retry after: {ex.RetryAfter.Value.TotalSeconds} seconds.");
+                }
+                else
+                {
+                    _logger.Warning($"{postItemMessage.ResourceUrl}: Rate limit exceeded. Please try again later.");
+                }
+                throw;
+            }
+            catch (Exception ex)
             {
                 _logger.Error(
                     $"{postItemMessage.ResourceUrl} (source id: {id}): An unhandled exception occurred in the PostResource block: {ex}");
@@ -568,7 +568,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
             /// The relative resource URL of the resource being processed for which a missing dependency was identified.
             /// </summary>
             public string DependentResourceUrl { get; set; }
-            
+
             /// <summary>
             /// The property name of the reference which is the missing dependency.
             /// </summary>
@@ -589,7 +589,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
             /// </summary>
             public string DependencyResourceUrl { get; set; }
         }
-        
+
         public IEnumerable<PostItemMessage> CreateProcessDataMessages(StreamResourcePageMessage<PostItemMessage> message, string json)
         {
             JArray items = JArray.Parse(json);

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
@@ -88,5 +88,11 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
         public bool UseChangeVersionPaging { get; set; }
 
         public int ChangeVersionPagingWindowSize { get; set; }
-    }
+
+        public bool EnableRateLimit { get; set; } = false;
+
+        public int RateLimitNumberExecutions { get; set; } = 100;
+
+		public int RateLimitTimeLimitMinutes { get; set; } = 1;
+	}
 }

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
@@ -9,12 +9,12 @@ using System.Threading;
 
 namespace EdFi.Tools.ApiPublisher.Core.Configuration
 {
-	public class ApiPublisherSettings
+    public class ApiPublisherSettings
     {
         public Options Options { get; set; }
 
         public AuthorizationFailureHandling[] AuthorizationFailureHandling { get; set; }
-        
+
         public string[] ResourcesWithUpdatableKeys { get; set; }
     }
 
@@ -27,15 +27,15 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
     public class Options
     {
         private readonly ILogger _logger = Log.Logger;
-        
+
         public int BearerTokenRefreshMinutes { get; set; } = 12;
-        
+
         public int RetryStartingDelayMilliseconds { get; set; } = 250;
-        
+
         public int MaxRetryAttempts { get; set; } = 5;
 
         public int MaxDegreeOfParallelismForResourceProcessing { get; set; } = 10;
-        
+
         private int _maxDegreeOfParallelismForPostResourceItem = 20;
 
         public int MaxDegreeOfParallelismForPostResourceItem
@@ -50,7 +50,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
 
                     return;
                 }
-                
+
                 // Limit setting to the number of threads available
                 ThreadPool.GetMaxThreads(out int workerThreadCount, out int completionPortThreadCount);
 
@@ -59,7 +59,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
                 int practicalMaxParallelization = Math.Min(200, workerThreadCount);
 
                 _maxDegreeOfParallelismForPostResourceItem = Math.Min(value, practicalMaxParallelization);
-                
+
                 if (value > _maxDegreeOfParallelismForPostResourceItem)
                 {
                     _logger.Warning($"Attempted max parallelism of '{value}' for posting resources is too large. Setting has been adjusted to '{_maxDegreeOfParallelismForPostResourceItem}'.");
@@ -93,6 +93,6 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
 
         public int RateLimitNumberExecutions { get; set; } = 100;
 
-		public int RateLimitTimeLimitMinutes { get; set; } = 1;
-	}
+        public int RateLimitTimeLimitMinutes { get; set; } = 1;
+    }
 }

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace EdFi.Tools.ApiPublisher.Core.Configuration
 {
-	public class ConfigurationBuilderFactory 
+    public class ConfigurationBuilderFactory
     {
         /// <summary>
         /// Creates a configuration builder incorporating settings files, environment variables and command-line arguments.
@@ -72,12 +72,12 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
                     ["--whatIf"] = "Options:WhatIf",
                     ["--useChangeVersionPaging"] = "Options:UseChangeVersionPaging",
                     ["--changeVersionPagingWindowSize"] = "Options:ChangeVersionPagingWindowSize",
-					["--enableRateLimit"] = "Options:EnableRateLimit",
-					["--rateLimitNumberExecutions"] = "Options:RateLimitNumberExecutions",
-					["--rateLimitTimeLimitMinutes"] = "Options:RateLimitTimeLimitMinutes",
+                    ["--enableRateLimit"] = "Options:EnableRateLimit",
+                    ["--rateLimitNumberExecutions"] = "Options:RateLimitNumberExecutions",
+                    ["--rateLimitTimeLimitMinutes"] = "Options:RateLimitTimeLimitMinutes",
 
-					// Resource selection (comma delimited paths - e.g. "/ed-fi/students,/ed-fi/studentSchoolAssociations")
-					["--include"] = "Connections:Source:Include",
+                    // Resource selection (comma delimited paths - e.g. "/ed-fi/students,/ed-fi/studentSchoolAssociations")
+                    ["--include"] = "Connections:Source:Include",
                     ["--includeOnly"] = "Connections:Source:IncludeOnly",
                     ["--exclude"] = "Connections:Source:Exclude",
                     ["--excludeOnly"] = "Connections:Source:ExcludeOnly",
@@ -86,14 +86,14 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
                     ["--resources"] = "Connections:Source:Resources",
                     ["--excludeResources"] = "Connections:Source:ExcludeResources",
                     ["--skipResources"] = "Connections:Source:SkipResources",
-                    
+
                     ["--treatForbiddenPostAsWarning"] = "Connections:Target:TreatForbiddenPostAsWarning",
                     ["--ignoreIsolation"] = "Connections:Source:IgnoreIsolation",
 
                     // PostgreSQL configuration store
                     ["--configurationStoreProvider"] = "ConfigurationStore:Provider",
                     ["--postgreSqlEncryptionPassword"] = "ConfigurationStore:PostgreSql:EncryptionPassword",
-                    
+
                     // Path to the folder containing for JavaScript extension for special handling and retries
                     ["--remediationsScriptFile"] = "Options:RemediationsScriptFile",
                 });

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
@@ -72,9 +72,12 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
                     ["--whatIf"] = "Options:WhatIf",
                     ["--useChangeVersionPaging"] = "Options:UseChangeVersionPaging",
                     ["--changeVersionPagingWindowSize"] = "Options:ChangeVersionPagingWindowSize",
+					["--enableRateLimit"] = "Options:EnableRateLimit",
+					["--rateLimitNumberExecutions"] = "Options:RateLimitNumberExecutions",
+					["--rateLimitTimeLimitMinutes"] = "Options:RateLimitTimeLimitMinutes",
 
-                    // Resource selection (comma delimited paths - e.g. "/ed-fi/students,/ed-fi/studentSchoolAssociations")
-                    ["--include"] = "Connections:Source:Include",
+					// Resource selection (comma delimited paths - e.g. "/ed-fi/students,/ed-fi/studentSchoolAssociations")
+					["--include"] = "Connections:Source:Include",
                     ["--includeOnly"] = "Connections:Source:IncludeOnly",
                     ["--exclude"] = "Connections:Source:Exclude",
                     ["--excludeOnly"] = "Connections:Source:ExcludeOnly",


### PR DESCRIPTION
### Changes:
Add Polly package for Rate Limit
- Add rate Limit options
- Add sample code to use Rate Limit with Retries
- Add sample exception

### Spike

For rate limit, the options are System.Threading.RateLimiting and Polly. Polly internally uses System.Threading.RateLimiting, and returns the same exceptions RateLimiterRejectedException.

Functionally, both options would be equivalent, however Polly implements additional policies.

In the context of the project, Polly is already used for the retry mechanism. According to the documentation, it is possible to combine both policies for the API call. According to this, it makes more sense to use Polly and take advantage of both rate limit and retry.
```
var policy = Policy.WrapAsync(rateLimiterPolicy, retryPolicy);
```

Therefore, it is recommended to implement the solution using Polly for the rate limit functionalities.

[Rate Limit Documentation](https://www.pollydocs.org/strategies/rate-limiter.html)