### PR TITLE
[APIPUB-84] [APIPUB-88] - Fix total count timeout and publishing with only 1 change

### DIFF
--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageProducers/EdFiApiChangeVersionPagingStreamResourcePageMessageProducer.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageProducers/EdFiApiChangeVersionPagingStreamResourcePageMessageProducer.cs
@@ -117,7 +117,9 @@ public class EdFiApiChangeVersionPagingStreamResourcePageMessageProducer : IStre
 
         }
 
-        _logger.Information($"{message.ResourceUrl}: Total count = {totalCount}");
+        _logger.Information("{ResourceUrl}: Total count = {TotalCount}",
+            message.ResourceUrl,
+            totalCount);
 
         // Flag the last page for special "continuation" processing
         if (pageMessages.Any())

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageProducers/EdFiApiChangeVersionReversePagingStreamResourcePageMessageProducer.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageProducers/EdFiApiChangeVersionReversePagingStreamResourcePageMessageProducer.cs
@@ -131,8 +131,9 @@ public class EdFiApiChangeVersionReversePagingStreamResourcePageMessageProducer 
             changeVersionWindow++;
 
         }
-        
-        _logger.Information($"{message.ResourceUrl}: Total count = {totalCount}");
+        _logger.Information("{ResourceUrl}: Total count = {TotalCount}",
+            message.ResourceUrl,
+            totalCount);
 
         // Flag the last page for special "continuation" processing
         if (pageMessages.Any())

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageProducers/EdFiApiChangeVersionReversePagingStreamResourcePageMessageProducer.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageProducers/EdFiApiChangeVersionReversePagingStreamResourcePageMessageProducer.cs
@@ -40,106 +40,99 @@ public class EdFiApiChangeVersionReversePagingStreamResourcePageMessageProducer 
             _logger.Information("{ResourceUrl}: Retrieving total count of items.", message.ResourceUrl);
         }
 
-        // Get total count of items in source resource for change window (if applicable)
-        var (totalCountSuccess, totalCount) = await _sourceTotalCountProvider.TryGetTotalCountAsync(
-            message.ResourceUrl,
-            options,
-            message.ChangeWindow,
-            errorHandlingBlock,
-            cancellationToken);
-
-        if (!totalCountSuccess)
-        {
-            // Allow processing to continue without performing additional work on this resource.
-            return Enumerable.Empty<StreamResourcePageMessage<TProcessDataMessage>>();
-        }
-
-        _logger.Information("{ResourceUrl}: Total count = {TotalCount}", message.ResourceUrl, totalCount);
-
         int limit = message.PageSize;
 
         var pageMessages = new List<StreamResourcePageMessage<TProcessDataMessage>>();
 
-        if (totalCount > 0)
+        var noOfPartitions = Math.Ceiling((decimal)(message.ChangeWindow.MaxChangeVersion - message.ChangeWindow.MinChangeVersion)
+                        / options.ChangeVersionPagingWindowSize);
+
+        // There must be at least 1 partition.
+        // APIPUB-84, Success ticket 2783
+        if (noOfPartitions == 0)
         {
-            var noOfPartitions = Math.Ceiling((decimal)(message.ChangeWindow.MaxChangeVersion - message.ChangeWindow.MinChangeVersion)
-                            / options.ChangeVersionPagingWindowSize);
+            noOfPartitions = 1;
+        }
 
-            int changeVersionWindow = 0;
-            long changeVersionWindowStartValue = message.ChangeWindow.MinChangeVersion;
+        int changeVersionWindow = 0;
+        long changeVersionWindowStartValue = message.ChangeWindow.MinChangeVersion;
+        long totalCount = 0;
 
-            while (changeVersionWindow < noOfPartitions)
+        while (changeVersionWindow < noOfPartitions)
+        {
+            long changeVersionWindowEndValue = (changeVersionWindowStartValue > 0 ?
+                changeVersionWindowStartValue - 1 : changeVersionWindowStartValue) + options.ChangeVersionPagingWindowSize;
+
+            if (changeVersionWindowEndValue > message.ChangeWindow.MaxChangeVersion)
             {
-                long changeVersionWindowEndValue = (changeVersionWindowStartValue > 0 ?
-                    changeVersionWindowStartValue - 1 : changeVersionWindowStartValue) + options.ChangeVersionPagingWindowSize;
+                changeVersionWindowEndValue = message.ChangeWindow.MaxChangeVersion;
+            }
+            var changeWindow = new ChangeWindow
+            {
+                MinChangeVersion = changeVersionWindowStartValue,
+                MaxChangeVersion = changeVersionWindowEndValue
+            };
+            changeVersionWindowStartValue = changeVersionWindowEndValue + 1;
 
-                if (changeVersionWindowEndValue > message.ChangeWindow.MaxChangeVersion)
+            // Get total count of items in source resource for change window (if applicable)
+            var (totalCountOnWindowSuccess, totalCountOnWindow) = await _sourceTotalCountProvider.TryGetTotalCountAsync(
+                message.ResourceUrl,
+                options,
+                changeWindow,
+                errorHandlingBlock,
+                cancellationToken);
+
+            if (!totalCountOnWindowSuccess)
+            {
+                // Allow processing to continue without performing additional work on this resource.
+                return Enumerable.Empty<StreamResourcePageMessage<TProcessDataMessage>>();
+            }
+
+            totalCount += totalCountOnWindow;
+            bool isLastOne = false;
+            long offsetOnWindow = totalCountOnWindow - limit;
+            if (offsetOnWindow < 0)
+            {
+                offsetOnWindow = 0;
+                isLastOne = true;
+            }
+
+            int limitOnWindow = totalCountOnWindow < limit ? (int)totalCountOnWindow : limit;
+            while (totalCountOnWindow > 0 && limitOnWindow > 0)
+            {
+                var pageMessage = new StreamResourcePageMessage<TProcessDataMessage>
                 {
-                    changeVersionWindowEndValue = message.ChangeWindow.MaxChangeVersion;
-                }
-                var changeWindow = new ChangeWindow
-                {
-                    MinChangeVersion = changeVersionWindowStartValue,
-                    MaxChangeVersion = changeVersionWindowEndValue
+                    // Resource-specific context
+                    ResourceUrl = message.ResourceUrl,
+                    PostAuthorizationFailureRetry = message.PostAuthorizationFailureRetry,
+
+                    // Page-strategy specific context
+                    Limit = limitOnWindow,
+                    Offset = offsetOnWindow,
+
+                    // Global processing context                   
+                    ChangeWindow = changeWindow,
+                    CreateProcessDataMessages = createProcessDataMessages,
+
+                    CancellationSource = message.CancellationSource,
                 };
-                changeVersionWindowStartValue = changeVersionWindowEndValue + 1;
 
-                // Get total count of items in source resource for change window (if applicable)
-                var (totalCountOnWindowSuccess, totalCountOnWindow) = await _sourceTotalCountProvider.TryGetTotalCountAsync(
-                    message.ResourceUrl,
-                    options,
-                    changeWindow,
-                    errorHandlingBlock,
-                    cancellationToken);
-
-                if (!totalCountOnWindowSuccess)
-                {
-                    continue;
-                }
-
-                bool isLastOne = false;
-                long offsetOnWindow = totalCountOnWindow - limit;
+                pageMessages.Add(pageMessage);
+                offsetOnWindow -= limit;
+                if (isLastOne)
+                    break;
                 if (offsetOnWindow < 0)
                 {
+                    limitOnWindow = limit + (int)offsetOnWindow;
                     offsetOnWindow = 0;
                     isLastOne = true;
                 }
-
-                int limitOnWindow = totalCountOnWindow < limit ? (int)totalCountOnWindow : limit;
-                while (totalCountOnWindow > 0 && limitOnWindow > 0)
-                {
-                    var pageMessage = new StreamResourcePageMessage<TProcessDataMessage>
-                    {
-                        // Resource-specific context
-                        ResourceUrl = message.ResourceUrl,
-                        PostAuthorizationFailureRetry = message.PostAuthorizationFailureRetry,
-
-                        // Page-strategy specific context
-                        Limit = limitOnWindow,
-                        Offset = offsetOnWindow,
-
-                        // Global processing context                   
-                        ChangeWindow = changeWindow,
-                        CreateProcessDataMessages = createProcessDataMessages,
-
-                        CancellationSource = message.CancellationSource,
-                    };
-
-                    pageMessages.Add(pageMessage);
-                    offsetOnWindow -= limit;
-                    if (isLastOne)
-                        break;
-                    if (offsetOnWindow < 0)
-                    {
-                        limitOnWindow = limit + (int)offsetOnWindow;
-                        offsetOnWindow = 0;
-                        isLastOne = true;
-                    }
-                }
-                changeVersionWindow++;
-
             }
+            changeVersionWindow++;
+
         }
+        
+        _logger.Information($"{message.ResourceUrl}: Total count = {totalCount}");
 
         // Flag the last page for special "continuation" processing
         if (pageMessages.Any())


### PR DESCRIPTION
This PR fixes issues in two Ed-Fi Success cases, 2795 and 2783.  The issue in 2783 appears to have been designated APIPUB-84 internally.  These two issues were combined into one PR because they both modify the same lines in the same files, and to avoid merge conflicts.

### Case 2795 - API Publisher times out making full min-max CV total count request
The API publisher has functionality to limit the maximum difference between min and max change version. The intent of this functionality is to reduce the load on the source Ed-Fi database, and allow GET requests to return more quickly. This was implemented as a "paging" strategy in API Publisher. In this strategy, the API Publisher correctly limits the change version window size when reading resources, but it still starts each resource with a totalCount request for the entire, unlimited, change version rage. In some deployments this query times out and causes the publisher to skip processing the affected resource. This applies to both the EdFiApiChangeVersionPagingStreamResourcePageMessageProducer and the EdFiApiChangeVersionReversePagingStreamResourcePageMessageProducer. 

The code in this PR looks like more changes than it really is, because an `if` statement was removed and code realigned.  Separate commits that make it easier to see what the actual changes are can be seen in the links below.
https://github.com/edanalytics/Ed-Fi-API-Publisher/commit/46b25497217838e53025ffc548230c8032c51a2b
https://github.com/edanalytics/Ed-Fi-API-Publisher/commit/0ffbd0c5450577db11a42e5f555c0b306817556e

### Case 2783 - API Publisher doesn't publish when only 1 change was made
Assume that API publisher is configured for a source and target, and has been publishing successfully. The lastChangeVersionProcessed is stored along with the connection information and was successfully updated the last time API publisher ran. Now, only one change is made in the source Ed-Fi environment and the change version value is incremented by 1. API Publisher correctly identifies that there are changes to process and begins looping through the configured resources, getting totalCount. During this process the value it uses for minChangeVersion in the API request is the value from lastChangeVersionsProcessed + 1. Because only one change was made on the source system, the value for minChangeVersion and maxChangeVersion now match. This is fine. When it reaches the resource where totalCount=1, it notes that in the log, but then never publishes the record. This only occurs when using the change version paging or reverse change version paging strategies, and is due to how the the number of "partitions" is calculated. There may be other ways to solve this issue, but I was able to solve it by ensuring that the number of partitions must always be 1 or more. 

A separate commit showing this fix is available here. https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-API-Publisher/commit/6f0f0fd5a9945083036941ec47be6886cb325c38
