### PR TITLE
[APIPUB-86] - API Publisher some exceptions are hidden when using a remediation script

### DIFF
--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/PostResourceProcessingBlocksFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/PostResourceProcessingBlocksFactory.cs
@@ -185,43 +185,42 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                             }
                             else
                             {
-                            if (javaScriptModuleFactory != null)
-                            {
-                                var remediationResult = await TryRemediateFailureAsync(
-                                    javaScriptModuleFactory,
-                                    retryAttempt,
-                                    targetEdFiApiClient,
-                                    _sourceConnectionDetails.Name,
-                                    postItemMessage.ResourceUrl,
-                                    id,
-                                    result.Result,
-                                    postItemMessage.Item.ToString());
-
-                                if (!remediationResult.FoundRemediation)
+                                if (javaScriptModuleFactory != null)
                                 {
-                                    knownUnremediatedRequests.Add((postItemMessage.ResourceUrl, result.Result.StatusCode));
+                                    var remediationResult = await TryRemediateFailureAsync(
+                                        javaScriptModuleFactory,
+                                        retryAttempt,
+                                        targetEdFiApiClient,
+                                        _sourceConnectionDetails.Name,
+                                        postItemMessage.ResourceUrl,
+                                        id,
+                                        result.Result,
+                                        postItemMessage.Item.ToString());
 
-                                    return;
-                                }
-
-                                // Check for a modified request body, and save it to the context
-                                if (remediationResult.ModifiedRequestBody is JsonElement modifiedRequestBody
-                                    && modifiedRequestBody.ValueKind != JsonValueKind.Null)
-                                {
-                                    if (_logger.IsEnabled(LogEventLevel.Debug))
+                                    if (!remediationResult.FoundRemediation)
                                     {
-                                        string modifiedRequestBodyJson = JsonSerializer.Serialize(
-                                            remediationResult.ModifiedRequestBody,
-                                            new JsonSerializerOptions { WriteIndented = true });
+                                        knownUnremediatedRequests.Add((postItemMessage.ResourceUrl, result.Result.StatusCode));
 
-                                        var message = $"{postItemMessage.ResourceUrl} (source id: {id}): Remediation plan provided a modified request body: {modifiedRequestBodyJson}";
-                                        _logger.Debug(message);
+                                        return;
                                     }
 
-                                    ctx["ModifiedRequestBody"] = remediationResult.ModifiedRequestBody;
-                                }
-                            }
+                                    // Check for a modified request body, and save it to the context
+                                    if (remediationResult.ModifiedRequestBody is JsonElement modifiedRequestBody
+                                        && modifiedRequestBody.ValueKind != JsonValueKind.Null)
+                                    {
+                                        if (_logger.IsEnabled(LogEventLevel.Debug))
+                                        {
+                                            string modifiedRequestBodyJson = JsonSerializer.Serialize(
+                                                remediationResult.ModifiedRequestBody,
+                                                new JsonSerializerOptions { WriteIndented = true });
 
+                                            var message = $"{postItemMessage.ResourceUrl} (source id: {id}): Remediation plan provided a modified request body: {modifiedRequestBodyJson}";
+                                            _logger.Debug(message);
+                                        }
+
+                                        ctx["ModifiedRequestBody"] = remediationResult.ModifiedRequestBody;
+                                    }
+                                }
                             
                                 string responseContent = await result.Result.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/PostResourceProcessingBlocksFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/PostResourceProcessingBlocksFactory.cs
@@ -178,6 +178,13 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                         delay,
                         async (result, ts, retryAttempt, ctx) =>
                         {
+                            if (result.Exception != null)
+                            {
+                                _logger.Warning(result.Exception, "{ResourceUrl} (source id: {Id}): POST attempt #{Attempts} failed with an exception. Retrying... (retry #{RetryAttempt} of {MaxRetryAttempts} with {TotalSeconds:N1}s delay):{NewLine}{Exception}",
+                                    postItemMessage.ResourceUrl, id, attempts, retryAttempt, options.MaxRetryAttempts, ts.TotalSeconds, Environment.NewLine, result.Exception);
+                            }
+                            else
+                            {
                             if (javaScriptModuleFactory != null)
                             {
                                 var remediationResult = await TryRemediateFailureAsync(
@@ -215,13 +222,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                                 }
                             }
 
-                            if (result.Exception != null)
-                            {
-                                _logger.Warning(result.Exception, "{ResourceUrl} (source id: {Id}): POST attempt #{Attempts} failed with an exception. Retrying... (retry #{RetryAttempt} of {MaxRetryAttempts} with {TotalSeconds:N1}s delay):{NewLine}{Exception}",
-                                    postItemMessage.ResourceUrl, id, attempts, retryAttempt, options.MaxRetryAttempts, ts.TotalSeconds, Environment.NewLine, result.Exception);
-                            }
-                            else
-                            {
+                            
                                 string responseContent = await result.Result.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                                 var message = $"{postItemMessage.ResourceUrl} (source id: {id}): POST attempt #{attempts} failed with status '{result.Result.StatusCode}'. Retrying... (retry #{retryAttempt} of {options.MaxRetryAttempts} with {ts.TotalSeconds:N1}s delay):{Environment.NewLine}{responseContent}";

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/PostResourceProcessingBlocksFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/PostResourceProcessingBlocksFactory.cs
@@ -214,14 +214,15 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                                                 remediationResult.ModifiedRequestBody,
                                                 new JsonSerializerOptions { WriteIndented = true });
 
-                                            var message = $"{postItemMessage.ResourceUrl} (source id: {id}): Remediation plan provided a modified request body: {modifiedRequestBodyJson}";
-                                            _logger.Debug(message);
+                                            _logger.Debug("{ResourceUrl} (source id: {Id}): Remediation plan provided a modified request body: {ModifiedRequestBodyJson}",
+                                                postItemMessage.ResourceUrl,
+                                                id,
+                                                modifiedRequestBodyJson);
                                         }
 
                                         ctx["ModifiedRequestBody"] = remediationResult.ModifiedRequestBody;
                                     }
                                 }
-                            
                                 string responseContent = await result.Result.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                                 var message = $"{postItemMessage.ResourceUrl} (source id: {id}): POST attempt #{attempts} failed with status '{result.Result.StatusCode}'. Retrying... (retry #{retryAttempt} of {options.MaxRetryAttempts} with {ts.TotalSeconds:N1}s delay):{Environment.NewLine}{responseContent}";


### PR DESCRIPTION
When using API Publisher with a remediation script, certain errors from POST attempts were not being written to the log. We noticed this while publishing to the TEA and assume the errors may have been related to rate limiting. Geoff McElhanon worked with us on this issue and suggested re-ordering the checks in PostResourceProcessingBlocksFactory.cs so that `result.Exception` is checked before applying remediation scripts. This change fixed our issue. I would recommend having him review this PR.  

The diff for this PR looks like more changes than it really is.  The first commit shows the actual fix.  The second commit realigns the code with correct indentation.  

This PR addresses success case 2796, and "APIPUB-86".