### PR TITLE
[APIPUB-113] - Add option --processDeletesAndKeyChangesOnFullPublish

### DIFF
--- a/docs/API-Publisher-Configuration.md
+++ b/docs/API-Publisher-Configuration.md
@@ -32,6 +32,7 @@ Defines general behavior of the Ed-Fi API Publisher.
 | Options:RateLimitMaxRetries<br/>`--rateLimitMaxRetries`                                                   | Indicates the number of times the Ed-Fi API publisher will attempt to _resend_ a request, rejected by rate limiting, to the source or destination APIs before determining that the failure is permanent.<br/>(_Default value: 10_) |
 | Options:useReversePaging<br/>`--useReversePaging`                                                         | Indicates whether or not to use reverse paging mode. For more information about this feature read [here](Reverse-Paging.md).<br/>(_Default value: false_) |
 | Options:LastChangeVersionProcessedNamespace<br />`--lastChangeVersionProcessedNamespace`                  | Indicates the namespace for change version tracking.  If provided, this string will be prepended to the target name when reading and writing the lastChangeVersionsProcessed named connection parameter. |
+| Options:ProcessDeletesAndKeyChangesOnFullPublish<br/>`--processDeletesAndKeyChangesOnFullPublish`         | When `true`, performs delete and key change processing even when the change window starts at version 1 or below (full publish). By default, these operations are skipped in full publish scenarios because it is assumed the target is empty.<br/>(_Default value: false_) |
 
 ## API Connections
 
@@ -73,6 +74,8 @@ Ed-Fi API Publisher will only process key changes and deletions if  specific Cha
 `--lastChangeVersionProcessed` value and set the `--useChangeVersionPaging` flag to true.
 Another option, if you want to keep the `--useChangeVersionPaging` false is defining a name for the source and target, using the
 `--sourceName` and `--targetName` values. More information about all these values [below](API-Publisher-Configuration.md#api-connections).
+
+When performing a full publish (change window starting at version 1 or below), delete and key change processing are skipped by default. Use `--processDeletesAndKeyChangesOnFullPublish=true` if you need these operations to run during a full publish.
 
 ## Authorization Failure Handling
 

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
@@ -100,5 +100,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
         public bool UseReversePaging { get; set; } = false;
 
         public string LastChangeVersionProcessedNamespace { get; set; }
+
+        public bool ProcessDeletesAndKeyChangesOnFullPublish { get; set; } = false;
     }
 }

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
@@ -80,7 +80,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
                     ["--rateLimitMaxRetries"] = "Options:RateLimitMaxRetries",
                     ["--useReversePaging"] = "Options:UseReversePaging",
                     ["--lastChangeVersionProcessedNamespace"] = "Options:LastChangeVersionProcessedNamespace",
-
+                    ["--processDeletesAndKeyChangesOnFullPublish"] = "Options:ProcessDeletesAndKeyChangesOnFullPublish",
 
                     // Resource selection (comma delimited paths - e.g. "/ed-fi/students,/ed-fi/studentSchoolAssociations")
                     ["--include"] = "Connections:Source:Include",

--- a/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
@@ -679,7 +679,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
                 return Array.Empty<TaskStatus>();
             }
 
-            if (changeWindow.MinChangeVersion <= 1)
+            if (changeWindow.MinChangeVersion <= 1 && !options.ProcessDeletesAndKeyChangesOnFullPublish)
             {
                 _logger.Information($"Change window starting value indicates all values are being published, and so there is no need to perform delete processing.");
                 return Array.Empty<TaskStatus>();
@@ -752,7 +752,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
                 return Array.Empty<TaskStatus>();
             }
 
-            if (changeWindow.MinChangeVersion <= 1)
+            if (changeWindow.MinChangeVersion <= 1 && !options.ProcessDeletesAndKeyChangesOnFullPublish)
             {
                 _logger.Information($"Change window starting value indicates all values are being published, and so there is no need to perform key change processing.");
                 return Array.Empty<TaskStatus>();


### PR DESCRIPTION
This PR adds a new option to the API Publisher allowing for deletes and key changes to be processed even when publishing from change version 1.  The original code attempts to optimize the first publish by skipping these steps.  This works under the assumption that the target ODS is empty when publishing from change version 1, and thus there would be no keys to change and no records to delete.  

However, this assumption is wrong quite often in the field.  For example, if the first full publish fails for any reason, the data in the target ODS remains and the API Publisher does not store a value for lastChangeVersionsProcessed.  Then, as source systems like a SIS continue to make updates to the source ODS, it's possible (and increasingly likely over time) that data will be deleted or have its keys changed.  When the second (or any subsequent) full publish happens there are now deletes and/or keyChanges that need to be processed, but the API Publisher continues to skip these steps under the assumption that the target ODS is empty, because it is starting from change version 1.

The code in this PR defaults to the original behavior to ensure that this is a non-breaking change.  However, it is our intention to enable this option everywhere we use API Publisher.  It might be worth considering changing the default.  

This code has been tested and is in use in Education Analytics production systems.  