### PR TITLE
[APIPUB-114] - Make knownUnremediatedRequests thread-safe

### DIFF
--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/PostResourceProcessingBlocksFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/PostResourceProcessingBlocksFactory.cs
@@ -74,7 +74,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
         public (ITargetBlock<PostItemMessage>, ISourceBlock<ErrorItemMessage>) CreateProcessingBlocks(
             CreateBlocksRequest createBlocksRequest)
         {
-            var knownUnremediatedRequests = new HashSet<(string resourceUrl, HttpStatusCode statusCode)>();
+            var knownUnremediatedRequests = new ConcurrentDictionary<(string resourceUrl, HttpStatusCode statusCode), byte>();
 
             var options = createBlocksRequest.Options;
 
@@ -120,7 +120,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
             Options options,
             Func<string> javaScriptModuleFactory,
             EdFiApiClient targetEdFiApiClient,
-            HashSet<(string resourceUrl, HttpStatusCode statusCode)> knownUnremediatedRequests,
+            ConcurrentDictionary<(string resourceUrl, HttpStatusCode statusCode), byte> knownUnremediatedRequests,
             Dictionary<string, string> missingDependencyByResourcePath)
         {
             if (ignoredResourceByUrl.ContainsKey(postItemMessage.ResourceUrl))
@@ -197,7 +197,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
 
                                     if (!remediationResult.FoundRemediation)
                                     {
-                                        knownUnremediatedRequests.Add((postItemMessage.ResourceUrl, result.Result.StatusCode));
+                                        knownUnremediatedRequests.TryAdd((postItemMessage.ResourceUrl, result.Result.StatusCode), 0);
 
                                         return;
                                     }
@@ -461,7 +461,7 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
 
             bool MayHaveRemediation(string resourceUrl, HttpStatusCode statusCode)
             {
-                return !knownUnremediatedRequests.Contains((resourceUrl, statusCode));
+                return !knownUnremediatedRequests.ContainsKey((resourceUrl, statusCode));
             }
 
             async Task<string> GetResponseMessageTextAsync(HttpResponseMessage response)


### PR DESCRIPTION
## Summary
Makes `knownUnremediatedRequests` thread-safe by switching it from a `HashSet` to a
`ConcurrentDictionary`. With `--maxDegreeOfParallelismForPostResourceItem` greater than 1
and a `--remediationsScriptFile` configured, a POST error not handled by the script could be
added to and read from that shared set concurrently, throwing "Operations that change
non-concurrent collections must have exclusive access" and faulting the PostResource block.

## Ticket
APIPUB-114 - non-concurrent collection error
https://edfi.atlassian.net/browse/APIPUB-114

## Credit
This is the fix from community PR #138 by @ea-mtenhoor (Mark TenHoor, edanalytics), re-homed to
an Ed-Fi-Alliance-OSS branch. The original PR is approved and CI-green but cannot be merged from
our side: it comes from an org-owned fork, so its branch cannot be updated to satisfy the
"branch up to date" requirement. Authorship is preserved via the Co-authored-by trailer, and
PR #138 will be closed with thanks referencing this PR.

## Type of Change
- [x] Bug fix

## What Changed
- `PostResourceProcessingBlocksFactory.cs`: `knownUnremediatedRequests` is now a
  `ConcurrentDictionary<(string, HttpStatusCode), byte>` (`Add` -> `TryAdd`, `Contains` -> `ContainsKey`).

## Testing
CI builds and runs the existing suite on the .NET 8 SDK. A concurrency regression test follows as
an immediate follow-up under APIPUB-114 (the current RemediationTests harness runs at parallelism 1,
where the race does not occur).
