### PR TITLE
APIPUB-113 Add option --processDeletesAndKeyChangesOnFullPublish

### DIFF
--- a/docs/API-Publisher-Configuration.md
+++ b/docs/API-Publisher-Configuration.md
@@ -32,6 +32,7 @@ Defines general behavior of the Ed-Fi API Publisher.
 | Options:RateLimitMaxRetries<br/>`--rateLimitMaxRetries`                                                   | Indicates the number of times the Ed-Fi API publisher will attempt to _resend_ a request, rejected by rate limiting, to the source or destination APIs before determining that the failure is permanent.<br/>(_Default value: 10_) |
 | Options:useReversePaging<br/>`--useReversePaging`                                                         | Indicates whether or not to use reverse paging mode. For more information about this feature read [here](Reverse-Paging.md).<br/>(_Default value: false_) |
 | Options:LastChangeVersionProcessedNamespace<br />`--lastChangeVersionProcessedNamespace`                  | Indicates the namespace for change version tracking.  If provided, this string will be prepended to the target name when reading and writing the lastChangeVersionsProcessed named connection parameter. |
+| Options:ProcessDeletesAndKeyChangesOnFullPublish<br/>`--processDeletesAndKeyChangesOnFullPublish`         | When `true`, performs delete and key change processing even when the change window starts at version 1 or below (full publish). By default, these operations are skipped in full publish scenarios because it is assumed the target is empty.<br/>(_Default value: false_) |
 
 ## API Connections
 
@@ -73,6 +74,8 @@ Ed-Fi API Publisher will only process key changes and deletions if  specific Cha
 `--lastChangeVersionProcessed` value and set the `--useChangeVersionPaging` flag to true.
 Another option, if you want to keep the `--useChangeVersionPaging` false is defining a name for the source and target, using the
 `--sourceName` and `--targetName` values. More information about all these values [below](API-Publisher-Configuration.md#api-connections).
+
+When performing a full publish (change window starting at version 1 or below), delete and key change processing are skipped by default. Use `--processDeletesAndKeyChangesOnFullPublish=true` if you need these operations to run during a full publish.
 
 ## Authorization Failure Handling
 

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
@@ -100,5 +100,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
         public bool UseReversePaging { get; set; } = false;
 
         public string LastChangeVersionProcessedNamespace { get; set; }
+
+        public bool ProcessDeletesAndKeyChangesOnFullPublish { get; set; } = false;
     }
 }

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
@@ -80,7 +80,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
                     ["--rateLimitMaxRetries"] = "Options:RateLimitMaxRetries",
                     ["--useReversePaging"] = "Options:UseReversePaging",
                     ["--lastChangeVersionProcessedNamespace"] = "Options:LastChangeVersionProcessedNamespace",
-
+                    ["--processDeletesAndKeyChangesOnFullPublish"] = "Options:ProcessDeletesAndKeyChangesOnFullPublish",
 
                     // Resource selection (comma delimited paths - e.g. "/ed-fi/students,/ed-fi/studentSchoolAssociations")
                     ["--include"] = "Connections:Source:Include",

--- a/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
@@ -679,7 +679,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
                 return Array.Empty<TaskStatus>();
             }
 
-            if (changeWindow.MinChangeVersion <= 1)
+            if (changeWindow.MinChangeVersion <= 1 && !options.ProcessDeletesAndKeyChangesOnFullPublish)
             {
                 _logger.Information($"Change window starting value indicates all values are being published, and so there is no need to perform delete processing.");
                 return Array.Empty<TaskStatus>();
@@ -752,7 +752,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
                 return Array.Empty<TaskStatus>();
             }
 
-            if (changeWindow.MinChangeVersion <= 1)
+            if (changeWindow.MinChangeVersion <= 1 && !options.ProcessDeletesAndKeyChangesOnFullPublish)
             {
                 _logger.Information($"Change window starting value indicates all values are being published, and so there is no need to perform key change processing.");
                 return Array.Empty<TaskStatus>();

--- a/src/EdFi.Tools.ApiPublisher.Tests/Processing/ProcessDeletesAndKeyChangesOnFullPublishTests.cs
+++ b/src/EdFi.Tools.ApiPublisher.Tests/Processing/ProcessDeletesAndKeyChangesOnFullPublishTests.cs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Bogus;
+using EdFi.Tools.ApiPublisher.Core.Configuration;
+using EdFi.Tools.ApiPublisher.Core.Processing;
+using EdFi.Tools.ApiPublisher.Tests.Extensions;
+using EdFi.Tools.ApiPublisher.Tests.Helpers;
+using EdFi.Tools.ApiPublisher.Tests.Models;
+using FakeItEasy;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EdFi.Tools.ApiPublisher.Tests.Processing
+{
+    // Covers the --processDeletesAndKeyChangesOnFullPublish option (APIPUB-113). On a full publish
+    // (change window starting at version 1 or below) delete and key change processing are skipped by
+    // default; the new opt-in flag forces them to run. The change window here resolves to
+    // MinChangeVersion = 1 because the source reports nothing processed to the target yet
+    // (GetSourceApiConnectionDetails(0) => MinChangeVersion = 1 + 0).
+    [TestFixture]
+    public class ProcessDeletesAndKeyChangesOnFullPublishTests
+    {
+        public abstract class When_full_publishing_with_updatable_keys : TestFixtureAsyncBase
+        {
+            private const int TestItemQuantity = 2;
+
+            protected ChangeProcessor _changeProcessor;
+            protected ChangeProcessorConfiguration _changeProcessorConfiguration;
+            protected string[] _resourcesWithUpdatableKeys;
+            protected IFakeHttpRequestHandler _fakeSourceRequestHandler;
+            protected IFakeHttpRequestHandler _fakeTargetRequestHandler;
+            protected List<KeyChange<FakeKey>> _suppliedKeyChanges;
+            protected List<GenericResource<FakeKey>> _suppliedTargetResources;
+
+            protected abstract bool ProcessDeletesAndKeyChangesOnFullPublish { get; }
+
+            protected override async Task ArrangeAsync()
+            {
+                // -----------------------------------------------------------------
+                //                      Source Requests
+                // -----------------------------------------------------------------
+                int changeVersion = 1001;
+
+                var keyValueFaker = TestHelpers.GetKeyValueFaker();
+
+                var keyChangeFaker = new Faker<KeyChange<FakeKey>>().StrictMode(true)
+                    .RuleFor(o => o.Id, f => Guid.NewGuid().ToString("n"))
+                    .RuleFor(o => o.ChangeVersion, f => changeVersion++)
+                    .Ignore(o => o.OldKeyValues)
+                    .RuleFor(o => o.OldKeyValuesObject, f => keyValueFaker.Generate())
+                    .Ignore(o => o.NewKeyValues)
+                    .RuleFor(o => o.NewKeyValuesObject, f => keyValueFaker.Generate());
+
+                _suppliedKeyChanges = keyChangeFaker.Generate(TestItemQuantity);
+
+                _fakeSourceRequestHandler = TestHelpers.GetFakeBaselineSourceApiRequestHandler()
+                    .AvailableChangeVersions(1100)
+                    .ResourceCount(responseTotalCountHeader: TestItemQuantity)
+                    .GetResourceData(@"/data/v3/ed-fi/\w+/keyChanges", _suppliedKeyChanges);
+
+                // -----------------------------------------------------------------
+                //                      Target Requests
+                // -----------------------------------------------------------------
+                int i = 0;
+
+                var targetResourceFaker = new Faker<GenericResource<FakeKey>>().StrictMode(true)
+                    .RuleFor(o => o.Id, f => Guid.NewGuid().ToString("n"))
+                    .RuleFor(o => o.SomeReference, f => _suppliedKeyChanges[i++].OldKeyValuesObject)
+                    .RuleFor(o => o.VehicleManufacturer, f => f.Vehicle.Manufacturer())
+                    .RuleFor(o => o.VehicleYear, f => f.Date.Between(DateTime.Today.AddYears(-50), DateTime.Today).Year);
+
+                _suppliedTargetResources = targetResourceFaker.Generate(TestItemQuantity);
+
+                _fakeTargetRequestHandler = A.Fake<IFakeHttpRequestHandler>()
+                    .SetBaseUrl(MockRequests.TargetApiBaseUrl)
+                    .SetDataManagementUrlSegment(EdFiApiConstants.DataManagementApiSegment)
+                    .SetChangeQueriesUrlSegment(EdFiApiConstants.ChangeQueriesApiSegment)
+                    .OAuthToken()
+                    .ApiVersionMetadata()
+                    .Dependencies();
+
+                for (int j = 0; j < TestItemQuantity; j++)
+                {
+                    _fakeTargetRequestHandler.GetResourceData(
+                        @"/data/v3/ed-fi/\w+",
+                        _suppliedKeyChanges[j].OldKeyValuesObject.ToQueryStringParams(),
+                        new[] { _suppliedTargetResources[j] });
+                }
+
+                // -----------------------------------------------------------------
+                //                  Source/Target Connection Details
+                // -----------------------------------------------------------------
+
+                // Full publish: nothing processed to the target yet, so MinChangeVersion resolves to 1.
+                var sourceApiConnectionDetails = TestHelpers.GetSourceApiConnectionDetails(0);
+                var targetApiConnectionDetails = TestHelpers.GetTargetApiConnectionDetails();
+
+                // -----------------------------------------------------------------
+                //                    Options and Configuration
+                // -----------------------------------------------------------------
+
+                var options = TestHelpers.GetOptions();
+                options.ProcessDeletesAndKeyChangesOnFullPublish = ProcessDeletesAndKeyChangesOnFullPublish;
+
+                TestHelpers.InitializeLogging();
+
+                _resourcesWithUpdatableKeys = TestHelpers.Configuration.GetResourcesWithUpdatableKeys();
+
+                _changeProcessorConfiguration = TestHelpers.CreateChangeProcessorConfiguration(
+                    options,
+                    resourcesWithUpdatableKeys: _resourcesWithUpdatableKeys);
+
+                _changeProcessor = TestHelpers.CreateChangeProcessorWithDefaultDependencies(
+                    options,
+                    sourceApiConnectionDetails,
+                    _fakeSourceRequestHandler,
+                    targetApiConnectionDetails,
+                    _fakeTargetRequestHandler);
+
+                await Task.Yield();
+            }
+
+            protected override async Task ActAsync()
+            {
+                await _changeProcessor.ProcessChangesAsync(_changeProcessorConfiguration, CancellationToken.None);
+            }
+        }
+
+        [TestFixture]
+        public class And_the_flag_is_not_set : When_full_publishing_with_updatable_keys
+        {
+            protected override bool ProcessDeletesAndKeyChangesOnFullPublish => false;
+
+            [Test]
+            public void Should_skip_key_change_processing_by_default()
+            {
+                // The source must never be queried for keyChanges (neither the support probe nor the data GET).
+                A.CallTo(() => _fakeSourceRequestHandler.Get(
+                        A<string>.Ignored,
+                        A<HttpRequestMessage>.That.Matches(
+                            msg => msg.RequestUri.LocalPath.EndsWith(EdFiApiConstants.KeyChangesPathSuffix))))
+                    .MustNotHaveHappened();
+            }
+        }
+
+        [TestFixture]
+        public class And_the_flag_is_set : When_full_publishing_with_updatable_keys
+        {
+            protected override bool ProcessDeletesAndKeyChangesOnFullPublish => true;
+
+            [Test]
+            public void Should_process_key_changes_from_the_source()
+            {
+                A.CallTo(() => _fakeSourceRequestHandler.Get(
+                        A<string>.Ignored,
+                        A<HttpRequestMessage>.That.Matches(
+                            msg => msg.RequestUri.LocalPath.EndsWith(EdFiApiConstants.KeyChangesPathSuffix))))
+                    .MustHaveHappened();
+            }
+        }
+
+        [TestFixture]
+        public class When_full_publishing_deletes_and_the_flag_is_set : TestFixtureAsyncBase
+        {
+            private ChangeProcessor _changeProcessor;
+            private ChangeProcessorConfiguration _changeProcessorConfiguration;
+            private IFakeHttpRequestHandler _fakeSourceRequestHandler;
+
+            protected override async Task ArrangeAsync()
+            {
+                var sourceResourceFaker = TestHelpers.GetGenericResourceFaker();
+                var suppliedSourceResources = sourceResourceFaker.Generate(5);
+
+                _fakeSourceRequestHandler = TestHelpers.GetFakeBaselineSourceApiRequestHandler()
+                    .AvailableChangeVersions(1100)
+                    .ResourceCount(responseTotalCountHeader: 1)
+                    .GetResourceData($"{EdFiApiConstants.DataManagementApiSegment}{TestHelpers.AnyResourcePattern}", suppliedSourceResources)
+                    .GetResourceData($"{EdFiApiConstants.DataManagementApiSegment}{TestHelpers.AnyResourcePattern}/deletes", Array.Empty<object>());
+
+                var fakeTargetRequestHandler = TestHelpers.GetFakeBaselineTargetApiRequestHandler();
+                fakeTargetRequestHandler.EveryDataManagementPostReturns200Ok();
+
+                // Full publish: nothing processed to the target yet, so MinChangeVersion resolves to 1.
+                var sourceApiConnectionDetails = TestHelpers.GetSourceApiConnectionDetails(0);
+                var targetApiConnectionDetails = TestHelpers.GetTargetApiConnectionDetails();
+
+                var options = TestHelpers.GetOptions();
+                options.IncludeDescriptors = false; // Shorten test execution time
+                options.ProcessDeletesAndKeyChangesOnFullPublish = true;
+
+                TestHelpers.InitializeLogging();
+
+                _changeProcessorConfiguration = TestHelpers.CreateChangeProcessorConfiguration(options);
+
+                _changeProcessor = TestHelpers.CreateChangeProcessorWithDefaultDependencies(
+                    options,
+                    sourceApiConnectionDetails,
+                    _fakeSourceRequestHandler,
+                    targetApiConnectionDetails,
+                    fakeTargetRequestHandler);
+
+                await Task.Yield();
+            }
+
+            protected override async Task ActAsync()
+            {
+                await _changeProcessor.ProcessChangesAsync(_changeProcessorConfiguration, CancellationToken.None);
+            }
+
+            [Test]
+            public void Should_process_deletes_from_the_source()
+            {
+                A.CallTo(() => _fakeSourceRequestHandler.Get(
+                        A<string>.Ignored,
+                        A<HttpRequestMessage>.That.Matches(
+                            msg => msg.RequestUri.LocalPath.EndsWith(EdFiApiConstants.DeletesPathSuffix))))
+                    .MustHaveHappened();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds an opt-in `--processDeletesAndKeyChangesOnFullPublish` option so the Publisher performs delete and key change processing even when the change window starts at version 1 or below (a full publish). The default is `false`, which preserves the current behavior of skipping those operations on a full publish, so this change is non-breaking. Adds test coverage for the previously-uncovered full-publish branch.

## What Changed
- New `ProcessDeletesAndKeyChangesOnFullPublish` option (default `false`) with the `--processDeletesAndKeyChangesOnFullPublish` command-line mapping.
- `ChangeProcessor` now only skips delete and key change processing on a full publish (`MinChangeVersion <= 1`) when the option is not set.
- Configuration documentation updated to describe the new option.
- Tests added for the full-publish branch: skipped by default, processed when the option is set (for both deletes and key changes).

## Architectural Decisions
The production change is authored by Mark TenHoor (edanalytics) in PR #137. Because that PR originates from an organization-owned fork with maintainer edits disabled, the required tests could not be added to its branch, so the change was re-homed to this base-repo branch with authorship preserved via a co-author trailer. PR #137 will be closed with a reference to this PR.

## Testing
### Automated
Added `ProcessDeletesAndKeyChangesOnFullPublishTests` (3 tests) on the existing `ChangeProcessor` test harness:
- Key changes are skipped on a full publish when the option is not set.
- Key changes are processed on a full publish when the option is set.
- Deletes are processed on a full publish when the option is set.

## Checklist
- [x] Automated tests added or updated
- [x] Manually tested (happy path + error path) — covered by automated tests
- [x] Branch up to date with target branch
- [x] Commit history clean and includes ticket ID
- [x] No commented-out code or TODO comments
- [x] PR focused on this ticket only
