### PR TITLE
APIPUB-116 Upgrade solution to .NET 10

### DIFF
--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@87b7050bc53ea08284295505d98d2aa94301e852 # v4.2
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Publish .NET Assemblies
         run: |

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@87b7050bc53ea08284295505d98d2aa94301e852 # v4.2
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Build
         run: ./build.ps1 -Command Build -Configuration Debug
@@ -58,7 +58,7 @@ jobs:
         uses: actions/dependency-review-action@9129d7d40b8c12c1ed0f60400d00c92d437adcce # v4.1.3
       - name: Initialize CodeQL
         if: success()
-        uses: github/codeql-action/init@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # codeql-bundle-v3.28.0
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: csharp, actions
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Perform CodeQL Analysis
         if: success()
-        uses: github/codeql-action/analyze@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # codeql-bundle-v3.28.0
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
   event_file:
     name: "Event File"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,8 +3,8 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-# Tag aspnet:8.0-alpine3.20
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine3.22@sha256:46be98e65c56f07528fd70dcd0e684b9fe762f4c7256402fcabb8daf45076ddf
+# Tag aspnet:10.0.11-alpine3.24
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:c4b29bf368004ad9076c1ab9bc91fb373561e3905b4345637e14e8b8c57e3be8
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ARG VERSION="1.3.0"
@@ -22,7 +22,7 @@ COPY ./Docker/plainTextNamedConnections.template.json /app/plainTextNamedConnect
 COPY ./Docker/run.sh /app/run.sh
 
 RUN apk update && \
-    apk --no-cache add --upgrade unzip=~6 dos2unix=~7 bash=~5 gettext=~0 openssl=3.5.1-r0 postgresql16-client=~16 icu=76.1-r1 curl=~8 && \
+    apk --no-cache add --upgrade unzip=~6 dos2unix=~7 bash=~5 gettext=~1 openssl=3.5.7-r0 postgresql16-client=~16 icu=78.1-r0 curl=~8 && \
     wget -nv -O /app/ApiPublisher.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.ApiPublisher/versions/${VERSION}/content && \
     unzip /app/ApiPublisher.zip 'EdFi.ApiPublisher/**' -d /app/ && \
     mv /app/EdFi.ApiPublisher/* /app/ && \

--- a/src/EdFi.Tools.ApiPublisher.Cli/EdFi.Tools.ApiPublisher.Cli.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Cli/EdFi.Tools.ApiPublisher.Cli.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>EdFiApiPublisher</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <NoWarn>NU5100, NU5124</NoWarn>
   </PropertyGroup>
@@ -14,14 +14,12 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.AwsCloudWatch" Version="4.4.42" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.7" />
   </ItemGroup>
   <ItemGroup>
     <None Update="apiPublisherSettings.json">

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws/EdFi.Tools.ApiPublisher.ConfigurationStore.Aws.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="7.0.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.0" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext/EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext/EdFi.Tools.ApiPublisher.ConfigurationStore.Plaintext.csproj
@@ -1,11 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql/EdFi.Tools.ApiPublisher.ConfigurationStore.PostgreSql.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />

--- a/src/EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer/EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer.csproj
+++ b/src/EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer/EdFi.Tools.ApiPublisher.ConfigurationStore.SqlServer.csproj
@@ -1,15 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.14.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.12.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/EdFi.Tools.ApiPublisher.Connections.Api.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/EdFi.Tools.ApiPublisher.Connections.Api.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -11,14 +11,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
     <PackageReference Include="Polly.RateLimiting" Version="8.6.1" />
     <PackageReference Include="Sandwych.QuickGraph.Core" Version="1.0.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.12.0.118525">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />

--- a/src/EdFi.Tools.ApiPublisher.Connections.Sqlite/EdFi.Tools.ApiPublisher.Connections.Sqlite.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Sqlite/EdFi.Tools.ApiPublisher.Connections.Sqlite.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="8.3.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.7" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Core\EdFi.Tools.ApiPublisher.Core.csproj" />

--- a/src/EdFi.Tools.ApiPublisher.Core/EdFi.Tools.ApiPublisher.Core.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Core/EdFi.Tools.ApiPublisher.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -11,16 +11,14 @@
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SmartFormat" Version="3.6.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
-    <PackageReference Include="System.Threading.RateLimiting" Version="9.0.7" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.7" />
+    <PackageReference Include="System.Threading.RateLimiting" Version="10.0.11" />
   </ItemGroup>
 </Project>

--- a/src/EdFi.Tools.ApiPublisher.Tests/EdFi.Tools.ApiPublisher.Tests.csproj
+++ b/src/EdFi.Tools.ApiPublisher.Tests/EdFi.Tools.ApiPublisher.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -15,11 +15,9 @@
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="4.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.7" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.7" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.7" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.11" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.11" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EdFi.Tools.ApiPublisher.Connections.Api\EdFi.Tools.ApiPublisher.Connections.Api.csproj" />

--- a/src/dev.Dockerfile
+++ b/src/dev.Dockerfile
@@ -4,8 +4,8 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 
-# tag sdk:8.0 alpine
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine3.22@sha256:071ec6075f01f91ceaef8f1eaed5d43873635d46441f99221473c456f37f8c20 AS build
+# tag sdk:10.0.11-alpine3.24
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:620e765fe18186c08399f7aa978f79f04b6bbf0ee1b3b8a91e2d5c9619e59da1 AS build
 WORKDIR /source
 
 COPY ./.editorconfig .editorconfig
@@ -36,8 +36,8 @@ FROM build AS publish
 RUN dotnet publish -c Release -o /app/EdFi.Tools.ApiPiblisher.Cli --no-build --nologo
 
 
-# Tag aspnet:8.0 alpine
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine3.22@sha256:46be98e65c56f07528fd70dcd0e684b9fe762f4c7256402fcabb8daf45076ddf
+# Tag aspnet:10.0.11-alpine3.24
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine@sha256:c4b29bf368004ad9076c1ab9bc91fb373561e3905b4345637e14e8b8c57e3be8
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 # Alpine image does not contain Globalization Cultures library so we need to install ICU library to get fopr LINQ expression to work
@@ -53,7 +53,7 @@ COPY ./Docker/logging.template.json /app/logging.template.json
 COPY ./Docker/plainTextNamedConnections.template.json /app/plainTextNamedConnections.template.json
 COPY ./Docker/run.sh /app/run.sh
 
-RUN apk --no-cache add --upgrade unzip=~6 dos2unix=~7 bash=~5 openssl=3.5.1-r0 gettext=~0 icu=76.1-r1 curl=~8 && \
+RUN apk --no-cache add --upgrade unzip=~6 dos2unix=~7 bash=~5 openssl=3.5.7-r0 gettext=~1 icu=78.1-r0 curl=~8 && \
     dos2unix /app/*.json && \
     dos2unix /app/*.sh && \
     chmod 700 /app/*.sh -- ** && \


### PR DESCRIPTION
## Summary
Retargets the API Publisher solution from .NET 8 to .NET 10, updates the Docker images to the .NET 10 Alpine base, and points the CI workflows at the .NET 10 SDK. .NET 8 reaches end of support on 2026-11-10; .NET 10 is the current LTS. No production code changes were required; the change is limited to project files, Dockerfiles, and CI workflows.

## Tickets
- APIPUB-116 Upgrade solution to .NET 10
- APIPUB-121 Update Docker images to .NET 10
- APIPUB-122 Update CI workflows to the .NET 10 SDK

## Type of Change
- [x] Refactor / Configuration

## What Changed
- Retargeted all nine projects from `net8.0` to `net10.0`.
- Bumped the .NET-cadence Microsoft/System packages from `9.0.7` to `10.0.11` (Microsoft.Extensions.*, System.Threading.RateLimiting, Microsoft.Data.Sqlite, System.DirectoryServices.Protocols, System.Drawing.Common, System.Security.Cryptography.Xml).
- Removed `System.Text.Json`, `System.Threading.Tasks.Dataflow`, and `System.Text.RegularExpressions` package references now provided by the shared framework in .NET 10 (NU1510 package pruning). In `Connections.Api` these surfaced as build errors due to `TreatWarningsAsErrors`.
- Left off-cadence packages unchanged (AWS SDK, Microsoft.Data.SqlClient, Microsoft.IdentityModel.*, analyzers, test SDK). NU1605 alignment (APIPUB-111) and the consolidated Dependabot pass (APIPUB-123) remain separate tickets.
- **Docker (APIPUB-121):** retargeted `src/Dockerfile` and `src/dev.Dockerfile` to the .NET 10 Alpine base images (digest-pinned) and re-resolved the apk pins for Alpine 3.24 (icu 78.1-r0, openssl 3.5.7-r0, and the breaking gettext 0→1). Compose assets and `run.sh` carry no framework references and are unchanged.
- Updated `on-pullrequest.yml` and `on-prerelease.yml` `dotnet-version` from `8.0.x` to `10.0.x` (APIPUB-122), and bumped the CodeQL init/analyze action to v4.37.6 so its CodeQL CLI can trace .NET 10 / C# 14.

## Testing
### Automated
- Full solution builds in Release with no new warnings (0 errors). The remaining NU1901 warning is a pre-existing low-severity advisory on AWSSDK.Core; the high-severity NU1903 advisories were cleared by the 10.0.11 bumps.
- Full unit test suite passes: 183/183 on net10.0.
- CI green: Build and Test, CodeQL, and docker-analysis for both `src/Dockerfile` and `src/dev.Dockerfile`.

### Manual (E2E)
- Ran the net10 build against a local Ed-Fi ODS/API v7 (Data Standard 4.0) in sandbox mode: a full publish and a change-version incremental publish each completed successfully; the incremental published only the delta.
- Built `src/dev.Dockerfile` from source: the image builds the net10.0 solution, its runtime is .NET 10.0.11, and the CLI runs in-container to its own config validation.

## Known Limitations / Follow-Up
- The prod `src/Dockerfile` downloads the published NuGet package, which does not exist until the v1.4 release, so its full build is a release-gate check; the base-image and apk changes are in and pass CI docker-analysis.
- NU1605 alignment (APIPUB-111), the consolidated Dependabot pass (APIPUB-123), and the docs refresh (APIPUB-124) are out of scope here.

## Checklist
- [x] Automated tests pass (183/183)
- [x] Manually tested (publish E2E + Docker image build/run)
- [x] Branch up to date with target branch
- [x] Commit history clean and includes ticket IDs
- [x] No commented-out code or TODO comments
- [x] PR focused on the .NET 10 platform retarget
